### PR TITLE
End Moment Fix: conditional heaviside function for LoadML

### DIFF
--- a/pycba/load.py
+++ b/pycba/load.py
@@ -1,21 +1,21 @@
 """
 PyCBA - Load module
 
-The load matrix represents the loads as a `List` of `Lists`. 
+The load matrix represents the loads as a `List` of `Lists`.
 Each list entry represents a single load and must be in the following format:
 
      Span No. | Load Type | Load Value | Distance a | Load Cover c
-     
-Load Types are: 
+
+Load Types are:
 
     1 - **Uniformly Distributed Loads**, which only have a load value; distances `a` and `c` are set to "0".
-    
+
     2 - **Point Loads**, located at `a` from the left end of the span; distances `c` is set to "0".
-    
+
     3 - **Partial UDLs**, starting at `a` for a distance of `c` (i.e. the cover) where $L >= a+c$.
-    
+
     4 - **Moment Load**, located at `a`; distances `c` is set to "0".
-    
+
 It has dimension `M` x 5, where `M` is the number of loads applied to the beam.
 
 The type alias `LoadMatrix` is defined as
@@ -728,7 +728,14 @@ class LoadML(Load):
         # res.x = x
 
         res.V = Va * np.ones(npts)
-        res.M = Va * x - m * self.H(x - a, 0.5)
+
+        if a == 0:
+            res.M = Va * x - m * self.H(x - a, 1)
+        elif a == L:
+            res.M = Va * x - m * self.H(x - a, 0)
+        else:
+            res.M = Va * x - m * self.H(x - a, 0.5)
+
         # res.M = np.array(
         #     [Va * xi - m if i > idx else Va * xi for i, xi in enumerate(x)]
         # )


### PR DESCRIPTION
This solution passes all tests in the repo, but not sure if it breaks anything else?

**Reference tests:**

1. Mid-span moment (identical results):

```python
import pycba as cba

L = [10]
EI = [30 * 600e7 * 1e-6]
R = [-1, 0, -1, 0]
LM = [[1, 4, 10, 5, 0]]

beam_analysis = cba.BeamAnalysis(L, EI, R, LM)
beam_analysis.analyze()
beam_analysis.plot_results()
```

_main branch:_
![test1_main](https://user-images.githubusercontent.com/18841910/173514570-436d1e72-7d52-4338-9208-bb965d289cd2.png)

_end_moment_fix branch:_
![test1_fix](https://user-images.githubusercontent.com/18841910/173514651-b99c557e-75c6-4c7b-b79a-e67e46cdd675.png)

2. End-span moments (PR fixes step at ends):

```python
import pycba as cba

L = [10]
EI = [30 * 600e7 * 1e-6]
R = [-1, 0, -1, 0]
LM_1 = [[1, 4, 10, 0, 0]]
LM_2 = [[1, 4, 10, 10, 0]]

beam_analysis = cba.BeamAnalysis(L, EI, R, LM_1)
beam_analysis.analyze()
beam_analysis.plot_results()

beam_analysis = cba.BeamAnalysis(L, EI, R, LM_2)
beam_analysis.analyze()
beam_analysis.plot_results()
```

_main branch:_
![test2a_main](https://user-images.githubusercontent.com/18841910/173515296-2313a171-47f2-4691-a74d-e7b5c7daa1e9.png)
![test2b_main](https://user-images.githubusercontent.com/18841910/173515343-e719e551-8de5-4288-9d32-0f1f346bf1f6.png)

_end_moment_fix branch:_
![test2a_fix](https://user-images.githubusercontent.com/18841910/173515369-3f9937e7-e18e-4b4b-af7b-b7f5e58b016d.png)
![test2b_fix](https://user-images.githubusercontent.com/18841910/173515377-4d51612e-6684-442e-b4d6-41a44c8f98e6.png)

3. Prestressed concrete example:

```python
import pycba as cba
import numpy as np

L = [32]
EI = [32.8 * 49.9e9 * 1e-6]
R = [-1, 0, -1, 0]

LM = np.array([
    [1, 4, 34695095.91380897, 0.0, 0],
    [1, 4, -34695095.91380897, 32000.0, 0],
    [1, 4, 34695095.91380897, 0.0, 0],
    [1, 4, -34695095.91380897, 32000.0, 0],
    [1, 4, 34695095.91380897, 0.0, 0],
    [1, 4, -34695095.91380897, 32000.0, 0],
    [1, 4, 42820095.91380897, 0.0, 0],
    [1, 4, -42820095.91380897, 32000.0, 0],
    [1, 4, 42820095.91380897, 0.0, 0],
    [1, 4, -42820095.91380897, 32000.0, 0],
    [1, 4, 42820095.91380897, 0.0, 0],
    [1, 4, -42820095.91380897, 32000.0, 0],
    [1, 4, 42820095.91380897, 0.0, 0],
    [1, 4, -42820095.91380897, 32000.0, 0],
    [1, 4, 42820095.91380897, 0.0, 0],
    [1, 4, -42820095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0],
    [1, 4, 50945095.91380897, 0.0, 0],
    [1, 4, -50945095.91380897, 32000.0, 0]
])

LM[:,2] *= 1e-6
LM[:,3] *= 1e-3
LM = LM.tolist()
LM.append([1, 1, 7.695090745199957, 0, 0])

beam_analysis = cba.BeamAnalysis(L, EI, R, LM)
beam_analysis.analyze()
beam_analysis.plot_results()
```

_main branch:_
![test3_main](https://user-images.githubusercontent.com/18841910/173515673-e68c6bdb-bb10-4965-ae7d-6f592590d65b.png)

_end_moment_fix branch:_
![test3_fix](https://user-images.githubusercontent.com/18841910/173515696-3d867c90-41bd-498e-a862-3e70e5cfe22d.png)

