### PR TITLE
Fix the wrong IL for 7-related spans

### DIFF
--- a/pycba/inf_lines.py
+++ b/pycba/inf_lines.py
@@ -119,7 +119,8 @@ class InfluenceLines:
             self.create_ils()
 
         x = self.vResults[0].results.x
-        idx = (np.abs(x - poi)).argmin()
+        dx = x[2]-x[1]
+        idx = np.where(np.abs(x - poi) <= dx*1e-6)[0][0]
         # find the nearest support to the poi
         idxr = (
             np.abs(np.cumsum(np.insert(self.ba.beam.mbr_lengths, 0, 0)) - poi)

--- a/tests/test_inf_lines.py
+++ b/tests/test_inf_lines.py
@@ -175,3 +175,17 @@ def test_parse_beam_notation():
     assert EI == pytest.approx([300000.0, 300000.0, 300000.0, 300000.0])
     assert R == [-1, -1, -1, 0, 0, 0, -1, 0, -1, -1]
     assert eType == [1, 2, 1, 1]
+
+
+def test_distcretization():
+    """
+    Confirm that poi rounding to find the closest idx for ILs works
+    """
+
+    beam_str = "P7R7R"
+    (L, EI, R, eType) = cba.parse_beam_string(beam_str)
+
+    ils = cba.InfluenceLines(L, EI, R, eType)
+    ils.create_ils(step=0.1)    
+    (x, y) = ils.get_il(7.0, "M")
+    assert np.linalg.norm(y) >= 5.7


### PR DESCRIPTION
The bug (wrong IL for 7-related spans) is caused by the precision of the float data type. 
Besides the fix, a new test for this bug has been added to pytest. 