### PR TITLE
Deflection shape fixes for all element types

### DIFF
--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -223,7 +223,7 @@ class BeamAnalysis:
 
         for i in range(self._n):
             dof_i = 2 * i
-            fmbr = self._beam.get_cnl(i)
+            fmbr = self._beam.get_ref(i)
             # Cumulatively apply forces in opposite direction
             f[dof_i : dof_i + 4] -= fmbr
         return f

--- a/src/pycba/beam.py
+++ b/src/pycba/beam.py
@@ -280,9 +280,10 @@ class Beam:
 
         return ispan, pos_in_span
 
-    def get_cnl(self, i_span: int) -> LoadCNL:
+    def get_ref(self, i_span: int) -> LoadCNL:
         """
-        Returns Consistent Nodal Loads for the member
+        Returns Released End Forces for the member; that is, the Consistent Nodal Loads
+        modified for the element type (i.e. releases)
 
         Parameters
         ----------
@@ -291,18 +292,18 @@ class Beam:
 
         Returns
         -------
-        cnl : LoadCNL
+        ref : LoadCNL
             The totalled CNL object for the member, considering all loads.
 
         """
-        cnl = np.zeros(4)
+        ref = np.zeros(4)
         L = self.mbr_lengths[i_span]
         eType = self.mbr_eletype[i_span]
 
         for load in self._loads:
             if load.i_span == i_span:
-                cnl += load.get_cnl(L, eType)
-        return cnl
+                ref += load.get_ref(L, eType)
+        return ref
 
     def get_span_k(self, i_span: int) -> np.ndarray:
         """

--- a/src/pycba/inf_lines.py
+++ b/src/pycba/inf_lines.py
@@ -118,45 +118,67 @@ class InfluenceLines:
         if not self.vResults:
             self.create_ils()
 
-        x = self.vResults[0].results.x
-        dx = x[2] - x[1]
-        idx = np.where(np.abs(x - poi) <= dx * 1e-6)[0][0]
-        #idx = np.abs(x - poi).argmin()
-        
+        x = self.vResults[0].results.x   
         npts = len(self.vResults)
         eta = np.zeros(npts)
         
-        #
-        # Getting the correct vertical reaction is tricky
-        # Should be relatively easy to extend to get moment reactions too.
+        # Preparations for reaction ILs
         #
         # Get vector of the node locations
         node_locations = np.cumsum(np.insert(self.ba.beam.mbr_lengths, 0, 0))
-        # The indices of the supported vertical DOFs wrt the node locations vector
-        vert_sup_dof_idx = np.where(np.array(self.ba._beam.restraints)[::2]==-1)[0]
-        # The locations then of these vertical supports
-        vert_sup_locs = node_locations[vert_sup_dof_idx]
-        # The index of the closest vertical support
-        closest_vert_sup_idx = np.abs(vert_sup_locs-poi).argmin()
-        # And its value
-        closest_vert_sup = vert_sup_locs[closest_vert_sup_idx]
-        # And now the indixe of this support in the node locations vector
-        node_idx = np.where(node_locations==closest_vert_sup)[0][0]
-        # And hence its index in the overall DOFs vector
-        dof_idx = 2*node_idx
-        
-        # Now we must link the supported DOF to the index in the BeamAnalysis reactions vector
+        # Link the supported DOF to the index in the BeamAnalysis reactions vector
         idx_mask = np.zeros_like(self.ba._beam.restraints)
         idx_mask[np.where(np.array(self.ba._beam.restraints)==-1)] = np.arange(self.ba.beam.no_fixed_restraints)
-        # And finally the index of the vertical support nearest the POI in the reactions vector
-        vert_sup_idx = idx_mask[dof_idx]
 
-        for i, res in enumerate(self.vResults):
-            if load_effect == "V":
+        #idx = np.abs(x - poi).argmin()
+        
+        if load_effect.upper() == "V":
+            dx = x[2] - x[1]
+            idx = np.where(np.abs(x - poi) <= dx * 1e-6)[0][0]
+            for i, res in enumerate(self.vResults):
                 eta[i] = res.results.V[idx]
-            elif load_effect == "R":
+        
+        elif load_effect.upper() == "R":
+            #
+            # Getting the correct reaction is tricky
+            #
+            # The indices of the supported DOFs wrt the node locations vector
+            vert_sups_dof_idx = np.where(np.array(self.ba._beam.restraints)[::2]==-1)[0]
+            # The locations then of these supports
+            vert_sups_locs = node_locations[vert_sups_dof_idx]
+            # The index of the closest support
+            closest_vert_sup_idx = np.abs(vert_sups_locs-poi).argmin()
+            # And its value
+            closest_vert_sup = vert_sups_locs[closest_vert_sup_idx]
+            # And now the index of this support in the node locations vector
+            vert_sup_node_idx = np.where(node_locations==closest_vert_sup)[0][0]
+            # And hence its index in the overall DOFs vector
+            vert_sup_dof_idx = 2*vert_sup_node_idx
+            # And finally the index of the support nearest the POI in the reactions vector
+            vert_sup_idx = idx_mask[vert_sup_dof_idx]            
+            
+            for i, res in enumerate(self.vResults):
                 eta[i] = res.R[vert_sup_idx]
-            else:
+       
+        elif load_effect.upper() == "MR":
+            #
+            # Follows the same logic for the vertical reaction
+            #
+            mt_sups_dof_idx = np.where(np.array(self.ba._beam.restraints)[1::2]==-1)[0]
+            mt_sups_locs = node_locations[mt_sups_dof_idx]
+            closest_mt_sup_idx = np.abs(mt_sups_locs-poi).argmin()
+            closest_mt_sup = mt_sups_locs[closest_mt_sup_idx]
+            mt_sup_node_idx = np.where(node_locations==closest_mt_sup)[0][0]
+            mt_sup_dof_idx = 2*mt_sup_node_idx+1
+            mt_sup_idx = idx_mask[mt_sup_dof_idx]
+            
+            for i, res in enumerate(self.vResults):
+                eta[i] = res.R[mt_sup_idx]
+        
+        else:
+            dx = x[2] - x[1]
+            idx = np.where(np.abs(x - poi) <= dx * 1e-6)[0][0]
+            for i, res in enumerate(self.vResults):
                 eta[i] = res.results.M[idx]
 
         return (np.array(self.pos), eta)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,6 +7,243 @@ import numpy as np
 import pycba as cba
 
 
+def test_1span_ee():
+    """
+    Test fixed-fixed beam with point load in the middle
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, -1]
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM)
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(-P*L/8)
+    assert Mb == pytest.approx(-P*L/8)
+    assert Mc == pytest.approx(P*L/8)
+
+
+def test_1span_ep():
+    """
+    Test fixed-pinned beam with point load in the middle
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, 0]
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM)
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(-3*P*L/16)
+    assert Mb == pytest.approx(0)
+    assert Mc == pytest.approx(5*P*L/32)
+
+
+def test_1span_ep_eletype2():
+    """
+    Test fixed-pinned beam with point load in the middle, using eleType 2
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, -1]  # Notice, fixed-fixed supports
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM, eletype=[2])
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(-3*P*L/16)
+    assert Mb == pytest.approx(0)
+    assert Mc == pytest.approx(5*P*L/32)
+
+
+def test_1span_pe():
+    """
+    Test pinned-fixed beam with point load in the middle
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, 0, -1, -1]
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM)
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(0)
+    assert Mb == pytest.approx(-3*P*L/16)
+    assert Mc == pytest.approx(5*P*L/32)
+
+
+def test_1span_pe_eletype3():
+    """
+    Test pinned-fixed beam with point load in the middle, using eleType 3
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, -1]  # Notice, fixed-fixed supports
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM, eletype=[3])
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(0)
+    assert Mb == pytest.approx(-3*P*L/16)
+    assert Mc == pytest.approx(5*P*L/32)
+
+
+def test_1span_pp():
+    """
+    Test pinned-pinned beam with point load in the middle
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, 0, -1, 0]
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM)
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(0)
+    assert Mb == pytest.approx(0)
+    assert Mc == pytest.approx(P*L/4)
+
+
+def test_1span_pp_eletype4():
+    """
+    Test pinned-pinned beam with point load in the middle, using eleType 4
+    """
+
+    P = 10  # kN
+    L = 10  # m
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, -1]  # Notice, fixed-fixed supports
+    LM = [[1, 2, P, 0.5*L, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM, eletype=[4])
+    out = beam_analysis.analyze()
+    assert out == 0
+
+    Ma = beam_analysis.beam_results.results.M[1]
+    Mb = beam_analysis.beam_results.results.M[-2]
+    Mc = beam_analysis.beam_results.results.M[51]
+
+    assert Ma == pytest.approx(0)
+    assert Mb == pytest.approx(0)
+    assert Mc == pytest.approx(P*L/4)
+
+
+def get_1span_beam_def(etype):
+    P = 10  # kN
+    L = 10  # m
+    a = 0.25*L
+    EI = 30 * 600e7 * 1e-6  # kNm2
+    R = [-1, -1, -1, -1]  # Notice, fixed-fixed supports
+    LM = [[1, 2, P, a, 0]]
+
+    beam_analysis = cba.BeamAnalysis([L], EI, R, LM, eletype=[etype])
+    beam_analysis.analyze()
+
+    d = beam_analysis.beam_results.results.D
+    dmax = min(d)
+
+    return P, L, EI, a, dmax
+
+
+def test_1span_def_ff():
+    """
+    Test fixed-fixed beam deflection for off-centre point load
+    """
+
+    P, L, EI, aa, dmax = get_1span_beam_def(etype=1)
+
+    # a>b
+    b = aa
+    a = L-b
+    ymax = -(2*P*a**3*b**2)/(3*(3*a+b)**2*EI)
+
+    assert dmax == pytest.approx(ymax, abs=1e-6)
+
+
+def test_1span_def_fp():
+    """
+    Test fixed-pinned beam deflection for off-centre point load
+    """
+    P, L, EI, aa, dmax = get_1span_beam_def(etype=2)
+
+    a = aa
+    b = L-a
+    ymax = -(P*a**2*b)/(6*EI)*(b/(3*L-a))**0.5
+
+    assert dmax == pytest.approx(ymax, abs=1e-6)
+
+
+def test_1span_def_pf():
+    """
+    Test pinned-fixed beam deflection for off-centre point load
+    """
+    P, L, EI, aa, dmax = get_1span_beam_def(etype=3)
+
+    b = aa
+    ymax = -(P*b)/(3*EI)*(L**2-b**2)**3/(3*L**2-b**2)**2
+
+    assert dmax == pytest.approx(ymax, abs=1e-6)
+
+
+def test_1span_def_pp():
+    """
+    Test pinned-pinned beam deflection for off-centre point load
+    """
+    P, L, EI, aa, dmax = get_1span_beam_def(etype=4)
+
+    a = aa
+    ymax = -3**0.5*P*a*(L**2-a**2)**1.5/(27*EI*L)
+
+    assert dmax == pytest.approx(ymax, abs=1e-6)
+
+
 def test_2span_udl():
     """
     Execute a two-span beam analysis and check the reaction results.
@@ -101,7 +338,7 @@ def test_3span_diff_settlement():
     dmax = max(beam_analysis.beam_results.results.D)
     dmin = min(beam_analysis.beam_results.results.D)
     assert [dmax, dmin] == pytest.approx(
-        [0.0002778734578837245, -0.004648274177216889], abs=1e-6
+        [0.0002778734578837245, -0.004648274177216889], abs=1e-5
     )
 
 

--- a/tests/test_inf_lines.py
+++ b/tests/test_inf_lines.py
@@ -177,7 +177,7 @@ def test_parse_beam_notation():
     assert eType == [1, 2, 1, 1]
 
 
-def test_distcretization():
+def test_discretization():
     """
     Confirm that poi rounding to find the closest idx for ILs works
     """


### PR DESCRIPTION
This expands on #75 and ensure correct deflected shapes for each of the element types, facilitating correct single-span deflected shapes (for example). This necessitated a change to the architecture of consistent nodal loads and released end forces. 

If in future other releases are included, it would be better to move to a more general solution based on static condensation. Key references are:

- Wilson, E.L. (2002), Three-Dimensional Static and Dynamic Analysis of Structures, CSI Inc, Section 4.5.
- Paz, M. and Leigh, W. (2001), Integrated Matrix Analysis of Structures, Kluwer Academic Publishers, Section 1.9
- Logan, D.L. (2007), A First Course in the Finite Element Method, 4th Edn., Section 4.6
- Stallings, J.M. (1993), "Member end released in framed structures", Computers & Structures, 46(3), pp.443-9

The test suite has been extensively expanded to confirm these deflections.

Also included is a small refactoring of the IL poi lookup such that moment reactions can now also be found by requesting "MR".