### PR TITLE
Fix deflections for etype 3 and 4

### DIFF
--- a/src/pycba/results.py
+++ b/src/pycba/results.py
@@ -161,16 +161,14 @@ class BeamResults:
             Ma += cnl.Ma
             Mb += cnl.Mb
 
-        # Check element type for any released displacements
+        # If no releases, the rotation at i is easy
         R0 = d[1]
-        theta = 0
-        phi_i = 0
-        # Account for end release if joint not already rotating
-        if etype != 1 and abs(R0) < 1e-6:
+        
+        # Otherwise, check account for releases
+        if etype > 1:
             theta = (d[2] - d[0]) / L
-            phi_i = (L / (3 * EI)) * (-(f[1] - 0.5 * f[3]) + (Ma - 0.5 * Mb))
-
-        R0 -= phi_i - theta
+            phi = (L / (3 * EI)) * (-(f[1] - 0.5 * f[3]) + (Ma - 0.5 * Mb))
+            R0 = theta - phi
 
         # And superimpose end displacements using Moment-Area
         h = L / self.npts

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -434,6 +434,54 @@ def test_3span_hinge():
         [0.0008680555555555557, -0.0016677326388888887], abs=1e-6
     )
 
+def test_flipped_hinge():
+    # 3-span with etype 2
+    L = [5, 5, 10]
+    EI = 30 * 600e7 * np.ones(len(L)) * 1e-6
+    eType = [2, 1, 1]
+    R = [-1, -1, 0, 0, -1, 0, -1, -1]
+    LM = [[3, 2, 20, 5, 0]]
+    beam_analysis = cba.BeamAnalysis(L, EI, R, LM, eType)
+    out = beam_analysis.analyze()
+    d1 = beam_analysis.beam_results.results.D
+
+    # Same beam flipped, etype 3
+    L = [10, 5, 5]
+    EI = 30 * 600e7 * np.ones(len(L)) * 1e-6
+    eType = [1, 1, 3]
+    R = [-1, -1, -1, 0, 0, 0, -1, -1]
+    LM = [[1, 2, 20, 5, 0]]
+    beam_analysis = cba.BeamAnalysis(L, EI, R, LM, eType)
+    beam_analysis.analyze()
+    d2 = beam_analysis.beam_results.results.D
+
+    # Confirm flipped deflected shapes are close
+    assert d1 == pytest.approx(d2[::-1],abs=1e-7)
+    
+def test_hinges():
+    # Based on example in Logan's First Course in FE, Ex. 4.10    
+    a = 4
+    b = 2
+    P = 20
+    L = [a,b]
+    EI = 30 * 600e7 * 1e-6
+    EIvec = EI * np.ones(len(L))
+    eType = [1, 3]
+    R = [-1, -1, 0, 0, -1, -1]
+    LM = [[1, 2, P, a, 0]]
+    beam_analysis = cba.BeamAnalysis(L, EIvec, R, LM, eType)
+    beam_analysis.analyze()
+
+    phi2_1 = beam_analysis.beam_results.vRes[0].R[-2]
+    phi2_1_theory = -(a**2*b**3*P)/(2*(b**3+a**3)*EI)
+    
+    assert phi2_1_theory == pytest.approx(phi2_1)
+
+    phi2_2 = beam_analysis.beam_results.vRes[1].R[1]
+    phi2_2_theory = (a**3*b**2*P)/(2*(b**3+a**3)*EI)
+    
+    assert phi2_2_theory == pytest.approx(phi2_2)
+
 
 def test_3span_hinge_il():
     L = [5, 5, 10]


### PR DESCRIPTION
- Corrected for getting the initial rotation at the i node of elements with releases. 
- All elements now plot deflections correctly.
- Added new tests.