### PR TITLE
Release 0.8.0: guard nonlinear vs non-prismatic; release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 — 2026-06-11
 
 ### Features
+- **Nonlinear (elasto-plastic) beam analysis** (#140): `NonlinearBeamAnalysis`, an incremental analysis using the Generalized Clough concentrated-plasticity model. Tracks plastic-hinge formation and moment redistribution to collapse for both proportional static loading and moving vehicle loads, with rank-test mechanism detection. Prismatic members only — a non-prismatic (`SectionEI`) member raises a clear `TypeError`.
+- **Non-prismatic (variable-EI) elements** (#139): `SectionEI`, a member whose flexural rigidity varies along its length, built from `const` / `linear` / `pwl` / `poly` segments and analysed exactly by piece-by-piece flexibility integration. Scalar and `SectionEI` members can be mixed in one beam.
+- **Imposed-curvature (initial-strain) loads** (#139): load type 6 / `BeamAnalysis.add_ic`, a free curvature field for modelling creep, shrinkage and thermal effects.
 - Add coincident load effects to `Envelopes` (#122). New attributes `Vco_Mmax`, `Vco_Mmin`, `Mco_Vmax`, `Mco_Vmin` track the co-existing value of the other effect (V or M) at the truck position that caused each envelope extreme. `critical_values()` output now includes `"Vco"` and `"Mco"` keys. Coincident values are preserved through `augment()` and `zero_like()`.
 - Add trapezoidal (linearly varying) distributed load type (#101). Load type 5 supports both full-span `[span, 5, w1, w2]` and partial coverage `[span, 5, w1, w2, a, c]` where w1/w2 are intensities at positions a and a+c respectively. Also adds `BeamAnalysis.add_trap()` convenience method with optional `a` and `c` parameters.
 - Add `pos_start` and `pos_end` parameters to `BridgeAnalysis.run_vehicle()` to restrict the vehicle traverse range (#53). Useful for transverse deck analyses where the vehicle is confined to specific lanes.
 - Add `Envelopes.sum()` method for element-wise addition of compatible envelopes (#92). This enables superimposing load effects from different sources, e.g. a patterned UDL envelope with a moving vehicle envelope.
 - Fix `InfluenceLines.get_il()` raising `IndexError` when the point of interest does not fall exactly on the result grid (#89). This occurred with longer spans where the default 100-point discretization produced a grid spacing that could not match arbitrary poi values. The fix uses per-member result lookup, avoiding both the overly tight floating-point tolerance and the zero-valued padding indices at span boundaries.
+
+### Documentation
+- Migrated the documentation to Markdown (MyST); reorganised and expanded the Theoretical Basis page (elements, loads, nonlinear analysis); added tutorials for non-prismatic elements and imposed curvature (#139, #140).

--- a/docs/source/notebooks/nonlinear.ipynb
+++ b/docs/source/notebooks/nonlinear.ipynb
@@ -3,7 +3,25 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Nonlinear Beam Analysis\n\nPyCBA includes an incremental nonlinear analysis capability based on the **Generalized Clough model** for concentrated plasticity. This allows the formation and tracking of plastic hinges in continuous beams up to collapse.\n\nFor the full theoretical background — the $R$-parameter degradation law, element stiffness interpolation, hinge ownership, incremental algorithm, moving load transfer, and collapse detection — see the [Theoretical Basis](../theory.ipynb#Nonlinear-Analysis-—-Generalized-Clough-Model) page."
+   "source": [
+    "# Nonlinear Beam Analysis\n",
+    "\n",
+    "PyCBA includes an incremental nonlinear analysis capability based on the **Generalized Clough model** for concentrated plasticity. This allows the formation and tracking of plastic hinges in continuous beams up to collapse.\n",
+    "\n",
+    "For the full theoretical background — the $R$-parameter degradation law, element stiffness interpolation, hinge ownership, incremental algorithm, moving load transfer, and collapse detection — see the [Theoretical Basis](../theory.ipynb#Nonlinear-Analysis-—-Generalized-Clough-Model) page."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e75ad157",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note** — Nonlinear analysis supports **prismatic** (constant-$EI$) members only. The Generalized Clough element assumes a constant $EI$ per element, so passing a `SectionEI` (non-prismatic) member to `NonlinearBeamAnalysis` raises a `TypeError`. For variable-$EI$ members use the linear `BeamAnalysis` — see the [Non-prismatic Elements](nonprismatic.ipynb) tutorial.\n",
+    "\n",
+    "</div>"
+   ]
   },
   {
    "cell_type": "code",
@@ -47,19 +65,43 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "L, P, Mp, My = 12.0, 100.0, 432.0, 376.0\nEI = 67035.0\n\nnlba = cba.NonlinearBeamAnalysis(\n    L=[L, L], EI=EI,\n    R=[-1, 0, -1, 0, -1, 0],\n    Mp=Mp, My=My, q=0.0, mesh_size=0.5,\n)\nresult = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=5.0)\n\nlam_theory = 3 * Mp / (P * L / 2)\nerror_pct = abs(result.collapse_lambda - lam_theory) / lam_theory * 100\n\nprint(f\"Theoretical \\u03bb = {lam_theory:.4f}\")\nprint(f\"NFEA \\u03bb         = {result.collapse_lambda:.4f}\")\nprint(f\"Error           = {error_pct:.2f}%\")\nprint(f\"Collapsed       = {result.collapsed}\")"
+   "source": [
+    "L, P, Mp, My = 12.0, 100.0, 432.0, 376.0\n",
+    "EI = 67035.0\n",
+    "\n",
+    "nlba = cba.NonlinearBeamAnalysis(\n",
+    "    L=[L, L], EI=EI,\n",
+    "    R=[-1, 0, -1, 0, -1, 0],\n",
+    "    Mp=Mp, My=My, q=0.0, mesh_size=0.5,\n",
+    ")\n",
+    "result = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=5.0)\n",
+    "\n",
+    "lam_theory = 3 * Mp / (P * L / 2)\n",
+    "error_pct = abs(result.collapse_lambda - lam_theory) / lam_theory * 100\n",
+    "\n",
+    "print(f\"Theoretical \\u03bb = {lam_theory:.4f}\")\n",
+    "print(f\"NFEA \\u03bb         = {result.collapse_lambda:.4f}\")\n",
+    "print(f\"Error           = {error_pct:.2f}%\")\n",
+    "print(f\"Collapsed       = {result.collapsed}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "The hinge formation sequence shows which locations yielded and became plastic, and at what load factor:"
+   "source": [
+    "The hinge formation sequence shows which locations yielded and became plastic, and at what load factor:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "result.plot_hinge_history()\nplt.title(\"Hinge formation sequence\")\nplt.show()"
+   "source": [
+    "result.plot_hinge_history()\n",
+    "plt.title(\"Hinge formation sequence\")\n",
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -92,7 +134,27 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "w = 20.0\na_opt = L * (np.sqrt(2) - 1)\nlam_theory = 2 * Mp * (L + a_opt) / (w * a_opt * L * (L - a_opt))\n\nprint(f\"Optimal hinge location: x* = {a_opt:.2f} m\")\nprint(f\"Theoretical \\u03bb = {lam_theory:.4f}\")\nprint()\n\nfor ms in [2.0, 1.0, 0.5, 0.25]:\n    nlba = cba.NonlinearBeamAnalysis(\n        L=[L, L], EI=EI,\n        R=[-1, 0, -1, 0, -1, 0],\n        Mp=Mp, My=My, q=0.0, mesh_size=ms,\n    )\n    r = nlba.analyze(LM=[[1, 1, w]], lambda_max=5.0)\n    err = abs(r.collapse_lambda - lam_theory) / lam_theory * 100\n    locs = [h.location for h in r.hinge_events if h.event_type == 'plastic_hinge']\n    sag = [x for x in locs if x < L]\n    print(f\"  mesh = {ms:4.2f} m  |  \\u03bb = {r.collapse_lambda:.4f}  |  error = {err:5.2f}%  |  sagging hinge at x = {sag[0]:.2f} m\" if sag else f\"  mesh = {ms} m  |  no sagging hinge\")"
+   "source": [
+    "w = 20.0\n",
+    "a_opt = L * (np.sqrt(2) - 1)\n",
+    "lam_theory = 2 * Mp * (L + a_opt) / (w * a_opt * L * (L - a_opt))\n",
+    "\n",
+    "print(f\"Optimal hinge location: x* = {a_opt:.2f} m\")\n",
+    "print(f\"Theoretical \\u03bb = {lam_theory:.4f}\")\n",
+    "print()\n",
+    "\n",
+    "for ms in [2.0, 1.0, 0.5, 0.25]:\n",
+    "    nlba = cba.NonlinearBeamAnalysis(\n",
+    "        L=[L, L], EI=EI,\n",
+    "        R=[-1, 0, -1, 0, -1, 0],\n",
+    "        Mp=Mp, My=My, q=0.0, mesh_size=ms,\n",
+    "    )\n",
+    "    r = nlba.analyze(LM=[[1, 1, w]], lambda_max=5.0)\n",
+    "    err = abs(r.collapse_lambda - lam_theory) / lam_theory * 100\n",
+    "    locs = [h.location for h in r.hinge_events if h.event_type == 'plastic_hinge']\n",
+    "    sag = [x for x in locs if x < L]\n",
+    "    print(f\"  mesh = {ms:4.2f} m  |  \\u03bb = {r.collapse_lambda:.4f}  |  error = {err:5.2f}%  |  sagging hinge at x = {sag[0]:.2f} m\" if sag else f\"  mesh = {ms} m  |  no sagging hinge\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -117,7 +179,18 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "nlba = cba.NonlinearBeamAnalysis(\n    L=[L, L], EI=EI,\n    R=[-1, 0, -1, 0, -1, 0],\n    Mp=Mp, My=My, q=0.0, mesh_size=0.5,\n)\nresult = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=5.0, record_every=50)\n\nresult.plot_moments(Mp=Mp)\nplt.title(\"Moment redistribution during incremental loading\")\nplt.show()"
+   "source": [
+    "nlba = cba.NonlinearBeamAnalysis(\n",
+    "    L=[L, L], EI=EI,\n",
+    "    R=[-1, 0, -1, 0, -1, 0],\n",
+    "    Mp=Mp, My=My, q=0.0, mesh_size=0.5,\n",
+    ")\n",
+    "result = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=5.0, record_every=50)\n",
+    "\n",
+    "result.plot_moments(Mp=Mp)\n",
+    "plt.title(\"Moment redistribution during incremental loading\")\n",
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -142,7 +215,21 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "q_values = [0.0, 0.02, 0.05]\nlam_theory_q0 = 3 * Mp / (P * L / 2)\n\nfor q in q_values:\n    nlba = cba.NonlinearBeamAnalysis(\n        L=[L, L], EI=EI,\n        R=[-1, 0, -1, 0, -1, 0],\n        Mp=Mp, My=My, q=q, mesh_size=0.5,\n    )\n    r = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=10.0)\n    status = f\"collapse at \\u03bb = {r.collapse_lambda:.3f}\" if r.collapsed else f\"no collapse (\\u03bb_max reached)\"\n    increase = (r.collapse_lambda / lam_theory_q0 - 1) * 100 if r.collapsed else float('inf')\n    print(f\"q = {q:.2f}: {status}  ({increase:+.1f}% vs q=0 theory)\")"
+   "source": [
+    "q_values = [0.0, 0.02, 0.05]\n",
+    "lam_theory_q0 = 3 * Mp / (P * L / 2)\n",
+    "\n",
+    "for q in q_values:\n",
+    "    nlba = cba.NonlinearBeamAnalysis(\n",
+    "        L=[L, L], EI=EI,\n",
+    "        R=[-1, 0, -1, 0, -1, 0],\n",
+    "        Mp=Mp, My=My, q=q, mesh_size=0.5,\n",
+    "    )\n",
+    "    r = nlba.analyze(LM=[[1, 2, P, L / 2]], lambda_max=10.0)\n",
+    "    status = f\"collapse at \\u03bb = {r.collapse_lambda:.3f}\" if r.collapsed else f\"no collapse (\\u03bb_max reached)\"\n",
+    "    increase = (r.collapse_lambda / lam_theory_q0 - 1) * 100 if r.collapsed else float('inf')\n",
+    "    print(f\"q = {q:.2f}: {status}  ({increase:+.1f}% vs q=0 theory)\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -225,7 +312,40 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "cases = []\n\n# Case 1: Point load at midspan\nnlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\nr = nlba.analyze(LM=[[1, 2, 100, 6]], lambda_max=5.0)\ncases.append((\"Point load at midspan\", 3*Mp/(100*6), r.collapse_lambda))\n\n# Case 2: UDL on span 1\na = L*(np.sqrt(2)-1)\nnlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=1.0)\nr = nlba.analyze(LM=[[1, 1, 20]], lambda_max=5.0)\ncases.append((\"UDL on one span\", 2*Mp*(L+a)/(20*a*L*(L-a)), r.collapse_lambda))\n\n# Case 3: Two point loads\nnlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\nr = nlba.analyze(LM=[[1, 2, 100, 4], [1, 2, 75, 8]], lambda_max=5.0)\ncases.append((\"Two point loads\", 2*Mp/550, r.collapse_lambda))\n\n# Case 4: 3-span beam, UDL all spans (outer span governs)\nL3 = 10.0\na3 = L3*(np.sqrt(2)-1)\nnlba = cba.NonlinearBeamAnalysis(L=[L3,L3,L3], EI=EI, R=[-1,0,-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\nr = nlba.analyze(LM=[[1,1,20],[2,1,20],[3,1,20]], lambda_max=10.0)\ncases.append((\"3-span UDL (outer span)\", 2*Mp*(L3+a3)/(20*a3*L3*(L3-a3)), r.collapse_lambda))\n\nhdr_t = \"\\u03bb theory\"\nhdr_n = \"\\u03bb NFEA\"\nprint(f\"{'Case':<28s} {hdr_t:>10s} {hdr_n:>10s} {'Error':>8s}\")\nprint(\"-\" * 60)\nfor name, lt, ln in cases:\n    err = abs(ln - lt) / lt * 100\n    print(f\"{name:<28s} {lt:10.4f} {ln:10.4f} {err:7.2f}%\")"
+   "source": [
+    "cases = []\n",
+    "\n",
+    "# Case 1: Point load at midspan\n",
+    "nlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\n",
+    "r = nlba.analyze(LM=[[1, 2, 100, 6]], lambda_max=5.0)\n",
+    "cases.append((\"Point load at midspan\", 3*Mp/(100*6), r.collapse_lambda))\n",
+    "\n",
+    "# Case 2: UDL on span 1\n",
+    "a = L*(np.sqrt(2)-1)\n",
+    "nlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=1.0)\n",
+    "r = nlba.analyze(LM=[[1, 1, 20]], lambda_max=5.0)\n",
+    "cases.append((\"UDL on one span\", 2*Mp*(L+a)/(20*a*L*(L-a)), r.collapse_lambda))\n",
+    "\n",
+    "# Case 3: Two point loads\n",
+    "nlba = cba.NonlinearBeamAnalysis(L=[L, L], EI=EI, R=[-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\n",
+    "r = nlba.analyze(LM=[[1, 2, 100, 4], [1, 2, 75, 8]], lambda_max=5.0)\n",
+    "cases.append((\"Two point loads\", 2*Mp/550, r.collapse_lambda))\n",
+    "\n",
+    "# Case 4: 3-span beam, UDL all spans (outer span governs)\n",
+    "L3 = 10.0\n",
+    "a3 = L3*(np.sqrt(2)-1)\n",
+    "nlba = cba.NonlinearBeamAnalysis(L=[L3,L3,L3], EI=EI, R=[-1,0,-1,0,-1,0,-1,0], Mp=Mp, My=My, q=0.0, mesh_size=0.5)\n",
+    "r = nlba.analyze(LM=[[1,1,20],[2,1,20],[3,1,20]], lambda_max=10.0)\n",
+    "cases.append((\"3-span UDL (outer span)\", 2*Mp*(L3+a3)/(20*a3*L3*(L3-a3)), r.collapse_lambda))\n",
+    "\n",
+    "hdr_t = \"\\u03bb theory\"\n",
+    "hdr_n = \"\\u03bb NFEA\"\n",
+    "print(f\"{'Case':<28s} {hdr_t:>10s} {hdr_n:>10s} {'Error':>8s}\")\n",
+    "print(\"-\" * 60)\n",
+    "for name, lt, ln in cases:\n",
+    "    err = abs(ln - lt) / lt * 100\n",
+    "    print(f\"{name:<28s} {lt:10.4f} {ln:10.4f} {err:7.2f}%\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -254,20 +374,28 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "Mp_bridge = 2694.0\nL_bridge = 15.0\nP_static = 3 * Mp_bridge / (L_bridge / 2)\n\nnlba = cba.NonlinearBeamAnalysis(\n    L=[L_bridge, L_bridge],\n    EI=1_870_000.0,\n    R=[-1, 0, -1, 0, -1, 0],\n    Mp=Mp_bridge,\n    My=Mp_bridge / 1.15,\n    q=0.0,\n    mesh_size=0.5,\n)\n\nresult = nlba.analyze_moving(P=2 * P_static, step=0.5, n_sub=5, record_every=5)\n\nprint(f\"Static collapse load:   P = {P_static:.0f} kN\")\nprint(f\"Applied load:           P = {2*P_static:.0f} kN\")\nprint(f\"Collapsed:              {result.collapsed}\")\nif result.collapsed:\n    print(f\"Front axle at collapse: x = {result.collapse_lambda:.1f} m\")"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "fig, axs = plt.subplots(2, 1, figsize=(10, 7))\n\nresult.plot_hinge_history(moving=True, ax=axs[0])\naxs[0].set_title(\"Hinge events: load position vs hinge location\")\n\nresult.plot_moments(Mp=Mp_bridge, ax=axs[1])\naxs[1].set_title(\"Moment evolution during traverse\")\n\nplt.tight_layout()\nplt.show()"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "## Example 8 — Multi-Axle Vehicle Collapse\n\nThe `analyze_moving` method also accepts a `pycba.Vehicle` object for multi-axle vehicles. Here we define a heavy 3-axle truck and run it across the same bridge. The axle weights are scaled up to ensure collapse occurs during the traverse:"
+    "Mp_bridge = 2694.0\n",
+    "L_bridge = 15.0\n",
+    "P_static = 3 * Mp_bridge / (L_bridge / 2)\n",
+    "\n",
+    "nlba = cba.NonlinearBeamAnalysis(\n",
+    "    L=[L_bridge, L_bridge],\n",
+    "    EI=1_870_000.0,\n",
+    "    R=[-1, 0, -1, 0, -1, 0],\n",
+    "    Mp=Mp_bridge,\n",
+    "    My=Mp_bridge / 1.15,\n",
+    "    q=0.0,\n",
+    "    mesh_size=0.5,\n",
+    ")\n",
+    "\n",
+    "result = nlba.analyze_moving(P=2 * P_static, step=0.5, n_sub=5, record_every=5)\n",
+    "\n",
+    "print(f\"Static collapse load:   P = {P_static:.0f} kN\")\n",
+    "print(f\"Applied load:           P = {2*P_static:.0f} kN\")\n",
+    "print(f\"Collapsed:              {result.collapsed}\")\n",
+    "if result.collapsed:\n",
+    "    print(f\"Front axle at collapse: x = {result.collapse_lambda:.1f} m\")"
    ]
   },
   {
@@ -275,14 +403,65 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "truck = cba.Vehicle(axle_weights=[300, 600, 600], axle_spacings=[4.0, 1.5])\nprint(f\"Vehicle length: {truck.L:.1f} m\")\nprint(f\"Axle coordinates: {truck.axle_coords}\")\nprint(f\"Total weight: {sum(truck.axw):.0f} kN\")\n\nnlba = cba.NonlinearBeamAnalysis(\n    L=[L_bridge, L_bridge],\n    EI=1_870_000.0,\n    R=[-1, 0, -1, 0, -1, 0],\n    Mp=Mp_bridge,\n    My=Mp_bridge / 1.15,\n    q=0.0,\n    mesh_size=0.5,\n)\n\nresult = nlba.analyze_moving(vehicle=truck, step=0.5, n_sub=5, record_every=5)\n\nprint(f\"\\nCollapsed: {result.collapsed}\")\nif result.collapsed:\n    print(f\"Front axle at collapse: x = {result.collapse_lambda:.1f} m\")"
+   "source": [
+    "fig, axs = plt.subplots(2, 1, figsize=(10, 7))\n",
+    "\n",
+    "result.plot_hinge_history(moving=True, ax=axs[0])\n",
+    "axs[0].set_title(\"Hinge events: load position vs hinge location\")\n",
+    "\n",
+    "result.plot_moments(Mp=Mp_bridge, ax=axs[1])\n",
+    "axs[1].set_title(\"Moment evolution during traverse\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 8 — Multi-Axle Vehicle Collapse\n",
+    "\n",
+    "The `analyze_moving` method also accepts a `pycba.Vehicle` object for multi-axle vehicles. Here we define a heavy 3-axle truck and run it across the same bridge. The axle weights are scaled up to ensure collapse occurs during the traverse:"
+   ]
   },
   {
    "cell_type": "code",
-   "source": "result.plot_beam_state(vehicle=truck)\nplt.show()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "truck = cba.Vehicle(axle_weights=[300, 600, 600], axle_spacings=[4.0, 1.5])\n",
+    "print(f\"Vehicle length: {truck.L:.1f} m\")\n",
+    "print(f\"Axle coordinates: {truck.axle_coords}\")\n",
+    "print(f\"Total weight: {sum(truck.axw):.0f} kN\")\n",
+    "\n",
+    "nlba = cba.NonlinearBeamAnalysis(\n",
+    "    L=[L_bridge, L_bridge],\n",
+    "    EI=1_870_000.0,\n",
+    "    R=[-1, 0, -1, 0, -1, 0],\n",
+    "    Mp=Mp_bridge,\n",
+    "    My=Mp_bridge / 1.15,\n",
+    "    q=0.0,\n",
+    "    mesh_size=0.5,\n",
+    ")\n",
+    "\n",
+    "result = nlba.analyze_moving(vehicle=truck, step=0.5, n_sub=5, record_every=5)\n",
+    "\n",
+    "print(f\"\\nCollapsed: {result.collapsed}\")\n",
+    "if result.collapsed:\n",
+    "    print(f\"Front axle at collapse: x = {result.collapse_lambda:.1f} m\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.plot_beam_state(vehicle=truck)\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/src/pycba/__init__.py
+++ b/src/pycba/__init__.py
@@ -2,7 +2,7 @@
 PyCBA - Continuous Beam Analysis in Python
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from .analysis import BeamAnalysis
 from .beam import Beam

--- a/src/pycba/nonlinear.py
+++ b/src/pycba/nonlinear.py
@@ -39,6 +39,8 @@ import matplotlib.pyplot as plt
 from dataclasses import dataclass, field
 from typing import Optional, Union
 
+from .section import SectionEI
+
 
 # ---------------------------------------------------------------------------
 #  Data classes
@@ -450,6 +452,22 @@ class NonlinearBeamAnalysis:
         self.total_length = float(np.sum(self.span_L))
         self.span_R = list(R)
         self.q = q
+
+        # The Generalized Clough element assumes a constant EI per element, so
+        # non-prismatic (SectionEI) members are not supported.  Reject them with
+        # a clear message rather than failing later in a float() conversion.
+        ei_members = EI if isinstance(EI, (list, tuple, np.ndarray)) else [EI]
+        nonprismatic = [
+            i + 1 for i, e in enumerate(ei_members) if isinstance(e, SectionEI)
+        ]
+        if nonprismatic:
+            raise TypeError(
+                "NonlinearBeamAnalysis supports prismatic (constant-EI) members "
+                f"only; member(s) {nonprismatic} were supplied as SectionEI "
+                "(non-prismatic). Use BeamAnalysis for non-prismatic "
+                "(variable-EI) elastic analysis, or pass a scalar EI for "
+                "nonlinear analysis."
+            )
 
         _as = lambda v, n: np.full(n, float(v)) if isinstance(v, (int, float)) else np.atleast_1d(np.asarray(v, dtype=float))
         self.span_EI = _as(EI, self.n_spans)

--- a/tests/test_nonlinear.py
+++ b/tests/test_nonlinear.py
@@ -281,3 +281,22 @@ def test_three_span_symmetric_udl():
     assert any(abs(x - 10.0) <= 1.5 or abs(x - 20.0) <= 1.5 for x in locs), (
         f"No hinge near interior supports: {locs}"
     )
+
+
+def test_rejects_nonprismatic_member():
+    """NonlinearBeamAnalysis supports prismatic members only: a SectionEI
+    (non-prismatic) member must raise a clear error rather than failing later
+    in a cryptic float() conversion."""
+    from pycba.section import SectionEI
+
+    sec = SectionEI([("const", [0.0, L_SPAN], EI)])
+
+    # A SectionEI mixed into the per-span EI list.
+    with pytest.raises(TypeError, match="prismatic"):
+        NonlinearBeamAnalysis(
+            L=[L_SPAN, L_SPAN], EI=[sec, EI], R=[-1, 0, -1, 0, -1, 0], Mp=MP
+        )
+
+    # A single SectionEI applied to all spans.
+    with pytest.raises(TypeError, match="prismatic"):
+        NonlinearBeamAnalysis(L=[L_SPAN], EI=sec, R=[-1, 0, -1, 0], Mp=MP)


### PR DESCRIPTION
## Overview

Prepares the **0.8.0** release and hardens the newly-merged nonlinear analysis against unsupported inputs.

## Changes

### Guard nonlinear against non-prismatic members
The Generalized Clough element assumes a **constant `EI` per element**, so a `SectionEI` (non-prismatic) member is not supported. Previously, passing one failed deep inside a numpy `float()` conversion:

```
TypeError: float() argument must be a string or a real number, not 'SectionEI'
```

`NonlinearBeamAnalysis.__init__` now detects any `SectionEI` member up front and raises a clear, actionable error pointing users to `BeamAnalysis`. A regression test covers both a mixed `EI` list and a single `SectionEI`.

The nonlinear tutorial gains a note admonition documenting the prismatic-only limitation.

### Version 0.8.0 + release notes
`__version__` → `0.8.0`; `CHANGELOG.md`'s *Unreleased* section becomes **0.8.0**, with the three headline features at the top:

- **Nonlinear (elasto-plastic) beam analysis** (`NonlinearBeamAnalysis`) — #140
- **Non-prismatic (variable-EI) elements** (`SectionEI`) — #139
- **Imposed-curvature (initial-strain) loads** (`add_ic`, load type 6) — #139
- plus the Markdown (MyST) documentation migration

## Verification
- Full suite: **117 passed** (incl. the new `test_rejects_nonprismatic_member`).
- Docs build warning-free; the prismatic-only note renders correctly in the nonlinear tutorial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
