### PR TITLE
Display unit systems for plot labels

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -16,6 +16,7 @@
     pycba.results
     pycba.pattern
     pycba.render
+    pycba.units
     pycba.inf_lines
     pycba.bridge
     pycba.vehicle

--- a/docs/source/general.md
+++ b/docs/source/general.md
@@ -336,3 +336,58 @@ beam.plot(combo, load_cases=load_cases)   # draws the factored loads
 
 The underlying `pycba.render.BeamPlotter` class is also available directly if
 you want to build the renderer once and call both backends.
+
+## Units
+
+`PyCBA` is **unit-agnostic**: the solver performs no unit conversions, so any
+internally consistent set of units may be used (e.g. kN, m, kNm — or N, mm,
+N·mm) as long as every input shares the same system. Units surface only when a
+result is *plotted* — in the axis labels and the deflection display scale —
+and these are governed by a **display unit system**.
+
+The default is SI with kN and m, matching `PyCBA`'s historical labels, so
+nothing changes unless you ask for it. Choose a different system globally with
+`set_units`:
+
+```python
+cba.set_units("US-ft")   # kip, ft, kip·ft; deflection shown in inches
+```
+
+or override it for a single figure with the `units=` argument accepted by every
+plotting method (`plot_results`, `Beam.plot`, `BridgeAnalysis.plot_static`,
+`animate`, …):
+
+```python
+beam_analysis.plot_results(units="N-mm")
+beam.plot(units="US-in")
+bridge_analysis.plot_static(30.0, units="US-ft")
+```
+
+The built-in presets are:
+
+| Name | Force | Length | Moment | Deflection |
+| --- | --- | --- | --- | --- |
+| `"SI"` (default; also `"EU"`, `"AUS"`) | kN | m | kNm | mm |
+| `"SI-N-mm"` (`"N-mm"`) | N | mm | N·mm | mm |
+| `"US-ft"` (`"US"`) | kip | ft | kip·ft | in |
+| `"US-in"` | kip | in | kip·in | in |
+| `"none"` | — | — | — | — |
+
+`"none"` drops the unit labels entirely for a dimensionless presentation. For
+anything else, build a `pycba.units.UnitSystem` directly and pass it wherever a
+preset name is accepted:
+
+```python
+from pycba.units import UnitSystem
+
+mn_m = UnitSystem(
+    name="MN, m", force="MN", length="m", moment="MN·m",
+    distributed="MN/m", disp_label="mm", disp_scale=1000.0,
+)
+cba.set_units(mn_m)
+```
+
+Because this is a *display* layer only, the system you choose must match the
+units of your inputs — `PyCBA` does not convert the numbers for you. The
+deflection axis is the one place a number is rescaled for display
+(`disp_scale`, e.g. ×1000 to show metres as millimetres).

--- a/src/pycba/__init__.py
+++ b/src/pycba/__init__.py
@@ -18,6 +18,7 @@ from .load import (
 )
 from .results import BeamResults, Envelopes
 from .render import BeamPlotter
+from .units import UnitSystem, set_units, get_units
 from .inf_lines import InfluenceLines
 from .utils import parse_beam_string
 from .bridge import BridgeAnalysis

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -9,9 +9,12 @@ recovers reactions and member load effects.
 
 **PyCBA is unit-agnostic.** No conversions are performed; any internally
 consistent set of units (e.g. kN/m/kNm, or N/mm/Nmm) may be used as long as
-all inputs share the same system.  The only exception is :meth:`BeamAnalysis.plot_results`,
-which scales deflections by 1×10³ and labels the axis "mm" — that label is
-only correct when the length unit is metres.
+all inputs share the same system.  Units appear only when results are
+*plotted* — in the axis labels and the deflection display scale — governed by
+a display unit system (see :mod:`pycba.units` and :func:`pycba.set_units`).
+The default is SI with kN and m; pass ``units=`` to any plotting method, or
+call :func:`pycba.set_units`, to label a different system (the analysis itself
+is unaffected).
 
 Sign conventions
 ----------------

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -642,6 +642,8 @@ class BeamAnalysis:
             Forwarded to the backend renderer (``dimensions``, ``labels``,
             ``load_values``, ``color`` for matplotlib; ``standalone``,
             ``scale``, ``dimensions``, ``labels``, ``load_values`` for TikZ).
+            ``units`` selects the display unit system (see
+            :func:`pycba.set_units`).
 
         Returns
         -------
@@ -662,7 +664,7 @@ class BeamAnalysis:
             **kwargs,
         )
 
-    def plot_results(self, show_beam: bool = True, show: bool = True):
+    def plot_results(self, show_beam: bool = True, show: bool = True, units=None):
         """
         Plot bending moment, shear force, and deflection diagrams.
 
@@ -671,12 +673,6 @@ class BeamAnalysis:
         convention (y-axis inverted so sagging appears below the beam line).
         By default the loaded-beam schematic is drawn as a top panel sharing
         the x-axis, so the model and its load effects can be read together.
-
-        .. note::
-            The axis labels ("kNm", "kN", "mm") and the deflection scaling
-            (×1000) assume a kN / m unit system.  If a different consistent
-            unit system is used the plots will still be correct in shape but
-            the labels and deflection axis values will need interpretation.
 
         Parameters
         ----------
@@ -688,6 +684,11 @@ class BeamAnalysis:
             Call ``matplotlib.pyplot.show()`` before returning (default
             ``True``).  Set ``False`` to obtain the figure handles without
             displaying — e.g. to ``savefig`` or restyle the figure first.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the axis labels and the deflection scale
+            (e.g. ``"SI"``, ``"US-ft"``, ``"N-mm"``, ``"none"``).  Defaults to
+            the global default (see :func:`pycba.set_units`); the analysis
+            itself is unit-agnostic and unaffected.
 
         Returns
         -------
@@ -701,9 +702,12 @@ class BeamAnalysis:
         Has no effect and prints a warning if :meth:`analyze` has not been
         called yet.
         """
+        from .units import resolve
+
         if self._beam_results is None:
             print("Nothing to plot - run analysis first")
             return None
+        us = resolve(units)
         res = self._beam_results.results
         L = self._beam.length
 
@@ -717,7 +721,7 @@ class BeamAnalysis:
             )
             # The schematic stretches to fill its panel (equal_aspect=False) so
             # it stays aligned in x with the diagrams below.
-            self._beam.plot(ax=axs[0], dimensions=False, equal_aspect=False)
+            self._beam.plot(ax=axs[0], dimensions=False, equal_aspect=False, units=us)
             axs[0].set_xlabel("")
             diag = axs[1:]
         else:
@@ -729,20 +733,20 @@ class BeamAnalysis:
         ax.plot(res.x, res.M, "r")
         ax.invert_yaxis()
         ax.grid()
-        ax.set_ylabel("Bending Moment (kNm)")
+        ax.set_ylabel(us.moment_axis)
 
         ax = diag[1]
         ax.plot([0, L], [0, 0], "k", lw=2)
         ax.plot(res.x, res.V, "r")
         ax.grid()
-        ax.set_ylabel("Shear Force (kN)")
+        ax.set_ylabel(us.shear_axis)
 
         ax = diag[2]
         ax.plot([0, L], [0, 0], "k", lw=2)
-        ax.plot(res.x, res.D * 1e3, "r")
+        ax.plot(res.x, res.D * us.disp_scale, "r")
         ax.grid()
-        ax.set_ylabel("Deflection (mm)")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_ylabel(us.deflection_axis)
+        ax.set_xlabel(us.distance_axis)
 
         if show:
             plt.show()

--- a/src/pycba/beam.py
+++ b/src/pycba/beam.py
@@ -404,10 +404,12 @@ class Beam:
         **kwargs
             Forwarded to the backend renderer:
             :meth:`pycba.render.BeamPlotter.render_mpl`
-            (``dimensions``, ``labels``, ``load_values``, ``color``) or, when
-            ``tikz=True``, :meth:`pycba.render.BeamPlotter.render_tikz`
-            (``standalone``, ``scale``, ``dimensions``, ``labels``,
-            ``load_values``).
+            (``dimensions``, ``labels``, ``load_values``, ``color``,
+            ``units``) or, when ``tikz=True``,
+            :meth:`pycba.render.BeamPlotter.render_tikz` (``standalone``,
+            ``scale``, ``dimensions``, ``labels``, ``load_values``,
+            ``units``).  ``units`` selects the display unit system (see
+            :func:`pycba.set_units`).
 
         Returns
         -------

--- a/src/pycba/bridge.py
+++ b/src/pycba/bridge.py
@@ -447,7 +447,7 @@ class BridgeAnalysis:
 
         return env_ratios
 
-    def plot_static(self, pos: float, axs: Optional[plt.Axes] = None):
+    def plot_static(self, pos: float, axs: Optional[plt.Axes] = None, units=None):
         """
         Draw the bridge with the vehicle at a given position, above the
         instantaneous bending-moment and shear-force diagrams.
@@ -471,6 +471,8 @@ class BridgeAnalysis:
             is created and the analysis for ``pos`` is run first.  When axes
             are supplied the current results are used as-is: pass three axes
             (schematic + moment + shear) or two (moment + shear only).
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
@@ -478,6 +480,9 @@ class BridgeAnalysis:
             The figure and its axes when a new figure is created, otherwise
             ``None``.
         """
+        from .units import resolve
+
+        us = resolve(units)
         own_fig = axs is None
         fig = None
         if own_fig:
@@ -495,7 +500,7 @@ class BridgeAnalysis:
         L = self.ba.beam.length
 
         if len(axs) >= 3:  # schematic + load effects
-            self._draw_deck_and_vehicle(axs[0], pos)
+            self._draw_deck_and_vehicle(axs[0], pos, us)
             m_ax, v_ax = axs[1], axs[2]
         else:  # load effects only (e.g. the run_vehicle animation)
             m_ax, v_ax = axs[0], axs[1]
@@ -509,27 +514,29 @@ class BridgeAnalysis:
         for x in on_deck:
             m_ax.axvline(x, color="0.7", ls=":", lw=0.8, zorder=0)
         m_ax.grid()
-        m_ax.set_ylabel("Bending Moment (kNm)")
+        m_ax.set_ylabel(us.moment_axis)
 
         v_ax.plot([0, L], [0, 0], "k", lw=2)
         v_ax.plot(res.x, res.V, "r")
         for x in on_deck:
             v_ax.axvline(x, color="0.7", ls=":", lw=0.8, zorder=0)
         v_ax.grid()
-        v_ax.set_ylabel("Shear Force (kN)")
-        v_ax.set_xlabel("Distance along beam (m)")
+        v_ax.set_ylabel(us.shear_axis)
+        v_ax.set_xlabel(us.distance_axis)
 
         if own_fig:
             return fig, axs
 
-    def _draw_deck_and_vehicle(self, ax, pos: float):
+    def _draw_deck_and_vehicle(self, ax, pos: float, us=None):
         """
         Draw the deck schematic (supports + permanent loads) with the vehicle
         rendered as a small truck at ``pos`` on the given axes.
         """
         from matplotlib.patches import Rectangle, Circle
         from .render import BeamPlotter
+        from .units import resolve
 
+        us = resolve(us)
         L = self.ba.beam.length
         u = 0.05 * L  # symbol unit, matching the schematic renderer
 
@@ -541,6 +548,7 @@ class BridgeAnalysis:
             labels=True,
             load_values=bool(self.static_LM),
             equal_aspect=False,
+            units=us,
         )
         ax.set_xlabel("")
 
@@ -625,7 +633,7 @@ class BridgeAnalysis:
         ax.text(
             0.012,
             0.98,
-            "Vehicle: " + self._vehicle_spec(),
+            "Vehicle: " + self._vehicle_spec(us),
             transform=ax.transAxes,
             ha="left",
             va="top",
@@ -635,8 +643,11 @@ class BridgeAnalysis:
             zorder=10,
         )
 
-    def _vehicle_spec(self) -> str:
+    def _vehicle_spec(self, us=None) -> str:
         """A compact axle-group summary, e.g. ``3x150 + 2x120 + 40 kN``."""
+        from .units import resolve
+
+        us = resolve(us)
         w = self.veh.axw
         parts = []
         i = 0
@@ -647,7 +658,8 @@ class BridgeAnalysis:
             n = j - i + 1
             parts.append(f"{n}×{w[i]:g}" if n > 1 else f"{w[i]:g}")
             i = j + 1
-        return " + ".join(parts) + f" kN  (ΣW = {self.veh.W:g} kN)"
+        fu = f" {us.force}" if us.force else ""
+        return " + ".join(parts) + f"{fu}  (ΣW = {self.veh.W:g}{fu})"
 
     def animate(
         self,
@@ -657,6 +669,7 @@ class BridgeAnalysis:
         pos_start: Optional[float] = None,
         pos_end: Optional[float] = None,
         dpi: int = 110,
+        units=None,
     ):
         """
         Animate the vehicle crossing the bridge.
@@ -685,6 +698,8 @@ class BridgeAnalysis:
             ``beam length + vehicle length``, i.e. a full on-and-off crossing).
         dpi : int
             Resolution used when ``save`` is given.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
@@ -694,7 +709,9 @@ class BridgeAnalysis:
             ``FuncAnimation`` must be kept referenced while it plays.
         """
         from matplotlib.animation import FuncAnimation
+        from .units import resolve
 
+        us = resolve(units)
         # Analyse every position once, then animate from the stored results.
         self.run_vehicle(step, pos_start=pos_start, pos_end=pos_end)
         positions = list(self.pos)
@@ -738,22 +755,25 @@ class BridgeAnalysis:
             ax.grid(True)
             ax.set_ylabel(ylabel)
             if xlabel:
-                ax.set_xlabel("Distance along beam (m)")
+                ax.set_xlabel(us.distance_axis)
 
         def update(i):
             for ax in axs:
                 ax.cla()
             # Deck + moving truck (fixed deck view; the truck clips in/out)
-            self._draw_deck_and_vehicle(axs[0], positions[i])
+            self._draw_deck_and_vehicle(axs[0], positions[i], us)
             axs[0].set_xlim(*deck_xlim)
-            axs[0].set_title(f"Front axle at x = {positions[i]:.1f} m", fontsize=10)
+            lu = f" {us.length}" if us.length else ""
+            axs[0].set_title(
+                f"Front axle at x = {positions[i]:.1f}{lu}", fontsize=10
+            )
             _draw_effect(
                 axs[1], bmd[i], emin_b[i], emax_b[i], bmd_lo, bmd_hi,
-                "Bending Moment (kNm)",
+                us.moment_axis,
             )
             _draw_effect(
                 axs[2], sfd[i], emin_s[i], emax_s[i], sfd_lo, sfd_hi,
-                "Shear Force (kN)", xlabel=True,
+                us.shear_axis, xlabel=True,
             )
             return axs
 
@@ -767,7 +787,7 @@ class BridgeAnalysis:
 
         return anim
 
-    def plot_envelopes(self, env: Envelopes):
+    def plot_envelopes(self, env: Envelopes, units=None):
         """
         Plots the envelopes of load effects from a vehicle traverse analysis
 
@@ -776,12 +796,16 @@ class BridgeAnalysis:
         env : Envelopes
             An `pycba.Envelopes` object containing the results of a moving load
             analysis.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
         None
         """
+        from .units import resolve
 
+        us = resolve(units)
         L = self.ba.beam.length
         x = env.x
         nreactions = env.nsup
@@ -799,19 +823,23 @@ class BridgeAnalysis:
         ax.plot(x, env.Mmin, "b")
         ax.invert_yaxis()
         ax.grid()
-        ax.set_ylabel("Bending Moment (kNm)")
+        ax.set_ylabel(us.moment_axis)
 
         ax = axsLeft[1]
         ax.plot([0, L], [0, 0], "k", lw=2)
         ax.plot(x, env.Vmax, "r")
         ax.plot(x, env.Vmin, "b")
         ax.grid()
-        ax.set_ylabel("Shear Force (kN)")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_ylabel(us.shear_axis)
+        ax.set_xlabel(us.distance_axis)
 
         # Reactions in right panel
         subfigs[1].suptitle("Support Reactions")
 
+        # Reactions may be force or moment; show both unit labels.
+        react_u = (
+            f" ({us.force}/{us.moment})" if us.force and us.moment else ""
+        )
         # Check if consistent envelope
         if len(self.pos) == env.Rmax.shape[1]:
             axsRight = subfigs[1].subplots(nreactions, 1, sharex=True)
@@ -820,8 +848,8 @@ class BridgeAnalysis:
                 ax.plot(self.pos, env.Rmax[i, :], "r")
                 ax.plot(self.pos, env.Rmin[i, :], "b")
                 ax.grid()
-                ax.set_ylabel(f"Reaction {i+1} (kN/kNm)")
-            axsRight[-1].set_xlabel("Position of Front Axle (m)")
+                ax.set_ylabel(f"Reaction {i+1}{react_u}")
+            axsRight[-1].set_xlabel(us.length_axis("Position of Front Axle"))
 
         else:  # Otherwise envelope of envelopes
             axsRight = subfigs[1].subplots(2, 1, sharex=True)
@@ -836,7 +864,7 @@ class BridgeAnalysis:
                 ax.grid()
             axsRight[1].set_xlabel("Reaction ID")
 
-    def plot_ratios(self, env_ratios: Dict[str, np.ndarray]):
+    def plot_ratios(self, env_ratios: Dict[str, np.ndarray], units=None):
         """
         Plots the output of :meth:`pycba.bridge.BridgeAnalysis.envelopes_ratios`.
 
@@ -844,6 +872,9 @@ class BridgeAnalysis:
         ----------
         env_ratios : Dict[str,np.ndarray]
             The dictionary of envelopes ratios.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the distance axis (the ratios themselves
+            are dimensionless).  See :func:`pycba.set_units`.
 
         Raises
         ------
@@ -854,7 +885,9 @@ class BridgeAnalysis:
         -------
         None.
         """
+        from .units import resolve
 
+        us = resolve(units)
         # Set of keys we want to confirm are present
         check_keys = set(
             ["x", "Mmax", "Mmin", "Vmax", "Vmin", "nsup", "Rmax0", "Rmin0"]
@@ -888,7 +921,7 @@ class BridgeAnalysis:
         ax.plot(x, env_ratios["Vmin"], "b")
         ax.grid()
         ax.set_ylabel("Shear Force Ratio")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_xlabel(us.distance_axis)
 
         # Reactions in right panel
         subfigs[1].suptitle("Support Reactions")

--- a/src/pycba/inf_lines.py
+++ b/src/pycba/inf_lines.py
@@ -193,7 +193,9 @@ class InfluenceLines:
 
         return (np.array(self.pos), eta)
 
-    def plot_il(self, poi: float, load_effect: str, ax: Optional[plt.Axes] = None):
+    def plot_il(
+        self, poi: float, load_effect: str, ax: Optional[plt.Axes] = None, units=None
+    ):
         """
         Retrieves and plots the IL on either a supplied or new axes.
 
@@ -215,8 +217,12 @@ class InfluenceLines:
         ax : Optional[plt.Axes]
             A user-supplied matplotlib Axes object; when None (default), one is
             created for the plot.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the distance axis (see :func:`pycba.set_units`).
         """
+        from .units import resolve
 
+        us = resolve(units)
         (x, y) = self.get_il(poi, load_effect)
 
         if ax is None:
@@ -226,6 +232,6 @@ class InfluenceLines:
         ax.plot(x, y, "r")
         ax.grid()
         ax.set_ylabel("Influence Ordinate")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_xlabel(us.distance_axis)
         ax.set_title(f"IL for {load_effect} at {poi}")
         plt.tight_layout()

--- a/src/pycba/nonlinear.py
+++ b/src/pycba/nonlinear.py
@@ -109,7 +109,7 @@ class NonlinearResult:
     lambda_history: list[float] = field(default_factory=list)
     moment_history: list[np.ndarray] = field(default_factory=list)
 
-    def plot_moments(self, Mp=None, ax=None):
+    def plot_moments(self, Mp=None, ax=None, units=None):
         """Plot the bending moment distribution at collapse.
 
         If moment history snapshots were recorded (via ``record_every``),
@@ -122,11 +122,16 @@ class NonlinearResult:
             are drawn at +/- *Mp*.
         ax : matplotlib Axes, optional
             Axes to plot on.  If ``None``, a new figure is created.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
         ax : matplotlib Axes
         """
+        from .units import resolve
+
+        us = resolve(units)
         if ax is None:
             _, ax = plt.subplots(figsize=(10, 4))
 
@@ -149,8 +154,8 @@ class NonlinearResult:
 
         ax.invert_yaxis()
         ax.grid()
-        ax.set_ylabel("Bending Moment (kNm)")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_ylabel(us.moment_axis)
+        ax.set_xlabel(us.distance_axis)
         ax.legend()
 
         return ax
@@ -177,7 +182,7 @@ class NonlinearResult:
             )
             ax.add_patch(tri)
 
-    def plot_hinge_history(self, moving=False, ax=None):
+    def plot_hinge_history(self, moving=False, ax=None, units=None):
         """Plot the hinge formation sequence along the beam.
 
         Each event is shown as a marker at ``(x, stage)`` where *x* is the
@@ -197,11 +202,16 @@ class NonlinearResult:
             Default ``False`` (load factor).
         ax : matplotlib Axes, optional
             Axes to plot on.  If ``None``, a new figure is created.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
         ax : matplotlib Axes
         """
+        from .units import resolve
+
+        us = resolve(units)
         if ax is None:
             _, ax = plt.subplots(figsize=(10, 4))
 
@@ -223,15 +233,15 @@ class NonlinearResult:
             ax.plot([0, L], [1.0, 1.0], "k-", lw=2, zorder=2)
             ax.set_ylabel("Load factor $\\lambda$")
         else:
-            ax.set_ylabel("Front axle position (m)")
+            ax.set_ylabel(us.length_axis("Front axle position"))
 
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_xlabel(us.distance_axis)
         ax.legend()
         ax.grid(True, alpha=0.3)
 
         return ax
 
-    def plot_beam_state(self, vehicle=None, ax=None):
+    def plot_beam_state(self, vehicle=None, ax=None, units=None):
         """Plot the beam with hinge locations and optional vehicle position.
 
         Draws the beam, supports, and marks yield/hinge locations along
@@ -245,11 +255,16 @@ class NonlinearResult:
             position (``collapse_lambda``).
         ax : matplotlib Axes, optional
             Axes to plot on.  If ``None``, a new figure is created.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
 
         Returns
         -------
         ax : matplotlib Axes
         """
+        from .units import resolve
+
+        us = resolve(units)
         if ax is None:
             _, ax = plt.subplots(figsize=(10, 2.5))
 
@@ -303,9 +318,10 @@ class NonlinearResult:
                     )
 
             status = "collapse" if self.collapsed else "final"
-            ax.set_title(f"Vehicle at {status}: front axle x = {front:.1f} m")
+            lu = f" {us.length}" if us.length else ""
+            ax.set_title(f"Vehicle at {status}: front axle x = {front:.1f}{lu}")
 
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_xlabel(us.distance_axis)
         ax.set_xlim(-1, L + 1)
         ax.set_ylim(-1.5, 2.5)
         ax.set_aspect("equal")

--- a/src/pycba/render.py
+++ b/src/pycba/render.py
@@ -280,6 +280,7 @@ class BeamPlotter:
         load_values: bool = True,
         color: str = "tab:red",
         equal_aspect: bool = True,
+        units=None,
     ):
         """
         Draw the beam schematic with matplotlib.
@@ -313,7 +314,9 @@ class BeamPlotter:
             The axes the schematic was drawn into.
         """
         import matplotlib.pyplot as plt
+        from .units import resolve
 
+        self._us = resolve(units)
         L = self.L
         if L <= 0:
             raise ValueError("Cannot render a beam of zero length")
@@ -397,7 +400,7 @@ class BeamPlotter:
         ax.set_yticks([])
         for spine in ("top", "right", "left"):
             ax.spines[spine].set_visible(False)
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_xlabel(self._us.distance_axis)
         ax.grid(True, axis="x", ls=":", alpha=0.4)
         return ax
 
@@ -545,7 +548,7 @@ class BeamPlotter:
             ax.text(
                 x,
                 tail_y + (0.3 * sh if p.P >= 0 else -0.3 * sh),
-                f"{abs(p.P):g} kN",
+                self._us.fmt_force(abs(p.P)),
                 ha="center",
                 va="bottom" if p.P >= 0 else "top",
                 color=color,
@@ -593,9 +596,9 @@ class BeamPlotter:
         if show_val:
             same = abs(d.w0 - d.w1) < 1e-9
             lbl = (
-                f"{abs(d.w0):g} kN/m"
+                self._us.fmt_distributed(abs(d.w0))
                 if same
-                else f"{abs(d.w0):g}→{abs(d.w1):g} kN/m"
+                else self._us.fmt_distributed(abs(d.w0), abs(d.w1))
             )
             ax.text(
                 0.5 * (x0 + x1),
@@ -650,7 +653,7 @@ class BeamPlotter:
             ax.text(
                 x,
                 r + 0.5 * sh,
-                f"{abs(m.M):g} kNm",
+                self._us.fmt_moment(abs(m.M)),
                 ha="center",
                 va="bottom",
                 color=color,
@@ -718,6 +721,7 @@ class BeamPlotter:
         dimensions: bool = True,
         labels: bool = True,
         load_values: bool = True,
+        units=None,
     ) -> str:
         """
         Generate a TikZ/``stanli`` representation of the beam.
@@ -731,12 +735,18 @@ class BeamPlotter:
             Emit a ``stanli`` ``\\scaling`` factor.
         dimensions, labels, load_values : bool
             Toggle span dimensions, node labels and load-magnitude annotations.
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the load and dimension labels.  Defaults to
+            the global default (see :func:`pycba.set_units`).
 
         Returns
         -------
         str
             The LaTeX source.
         """
+        from .units import resolve
+
+        self._us = resolve(units)
         nodes = [self._node_name(i) for i in range(len(self.node_x))]
         lines: List[str] = []
         lines.append(
@@ -773,9 +783,10 @@ class BeamPlotter:
             dist = -max(1.0, 0.09 * self.L)
             for i in range(self.beam.no_spans):
                 span = self.node_x[i + 1] - self.node_x[i]
+                length_u = f"~{self._us.length}" if self._us.length else ""
                 lines.append(
                     f"\t\\dimensioning{{1}}{{{nodes[i]}}}{{{nodes[i + 1]}}}"
-                    f"{{{dist:g}}}[${span:g}$~m];"
+                    f"{{{dist:g}}}[${span:g}${length_u}];"
                 )
 
         if labels:
@@ -926,11 +937,13 @@ class BeamPlotter:
             out.append("\\end{scope}")
             if show_val:
                 pdist = -max(0.6, 0.055 * self.L)
+                du = f" {self._us.distributed}" if self._us.distributed else ""
+                lu = f"~{self._us.length}" if self._us.length else ""
                 for k, d in enumerate(self.dist_loads):
                     if abs(d.w0 - d.w1) < 1e-9:
-                        lbl = f"${abs(d.w0):g}$ kN/m"
+                        lbl = f"${abs(d.w0):g}${du}"
                     else:
-                        lbl = f"${abs(d.w0):g}\\rightarrow{abs(d.w1):g}$ kN/m"
+                        lbl = f"${abs(d.w0):g}\\rightarrow{abs(d.w1):g}${du}"
                     out.append(
                         f"\\notation{{5}}{{dl{k}a}}{{dl{k}b}}[{lbl}][0.5][above=8mm];"
                     )
@@ -940,7 +953,7 @@ class BeamPlotter:
                     if self._is_partial_dist(d):
                         out.append(
                             f"\\dimensioning{{1}}{{dl{k}a}}{{dl{k}b}}"
-                            f"{{{pdist:g}}}[${d.x1 - d.x0:g}$~m];"
+                            f"{{{pdist:g}}}[${d.x1 - d.x0:g}${lu}];"
                         )
 
         for k, p in enumerate(self.point_loads):
@@ -953,8 +966,9 @@ class BeamPlotter:
                 f"\\begin{{scope}}[color=red]\\load{{1}}{{pl{k}}}[{ang}][18mm]\\end{{scope}}"
             )
             if show_val:
+                fu = f" {self._us.force}" if self._us.force else ""
                 out.append(
-                    f"\\notation{{1}}{{pl{k}}}{{${abs(p.P):g}$ kN}}[above=20mm];"
+                    f"\\notation{{1}}{{pl{k}}}{{${abs(p.P):g}${fu}}}[above=20mm];"
                 )
 
         for k, m in enumerate(self.moment_loads):
@@ -969,8 +983,9 @@ class BeamPlotter:
                 f"\\begin{{scope}}[color=red]\\load{{{mtype}}}{{ml{k}}}\\end{{scope}}"
             )
             if show_val:
+                mu = f" {self._us.moment}" if self._us.moment else ""
                 out.append(
-                    f"\\notation{{2}}{{ml{k}}}{{${abs(m.M):g}$ kNm}}[above=5mm];"
+                    f"\\notation{{2}}{{ml{k}}}{{${abs(m.M):g}${mu}}}[above=5mm];"
                 )
         return out
 

--- a/src/pycba/results.py
+++ b/src/pycba/results.py
@@ -508,7 +508,7 @@ class Envelopes:
             self.Rmax = np.zeros((self.nsup, self.nres))
             self.Rmin = np.zeros((self.nsup, self.nres))
 
-    def plot(self, each=False, **kwargs):
+    def plot(self, each=False, units=None, **kwargs):
         """
         Plots the envelopes of bending and shear.
 
@@ -516,6 +516,8 @@ class Envelopes:
         ----------
         each : Boolean
             Wether or not to show each BMD and SFD in the enveloping. The default is False
+        units : str or pycba.units.UnitSystem, optional
+            Display unit system for the labels (see :func:`pycba.set_units`).
         **kwargs : Dict
             Matplotlib keyword arguments for plotting.
 
@@ -524,7 +526,9 @@ class Envelopes:
         None.
 
         """
+        from .units import resolve
 
+        us = resolve(units)
         if self.nres < 1:
             raise ValueError("No results to display")
 
@@ -538,15 +542,15 @@ class Envelopes:
         ax.plot(self.x, self.Mmin, "b")
         ax.grid()
         ax.invert_yaxis()
-        ax.set_ylabel("Bending Moment (kNm)")
+        ax.set_ylabel(us.moment_axis)
 
         ax = axs[1]
         ax.plot([0, L], [0, 0], "k", lw=2)
         ax.plot(self.x, self.Vmax, "r")
         ax.plot(self.x, self.Vmin, "b")
         ax.grid()
-        ax.set_ylabel("Shear Force (kN)")
-        ax.set_xlabel("Distance along beam (m)")
+        ax.set_ylabel(us.shear_axis)
+        ax.set_xlabel(us.distance_axis)
 
         if each:
             for res in self.vResults:

--- a/src/pycba/units.py
+++ b/src/pycba/units.py
@@ -1,0 +1,234 @@
+"""
+PyCBA - Display unit systems.
+
+PyCBA's solver is **unit-agnostic**: it performs no unit conversions, so any
+internally consistent set of units (e.g. kN/m/kNm, or N/mm/Nmm) may be used as
+long as all inputs share the same system.  This module does **not** change that
+contract - it only governs how plots are *labelled* and how deflections are
+*scaled for display*.
+
+A :class:`UnitSystem` is a small, immutable bundle of label strings (force,
+length, moment, distributed load) plus a deflection display scale/label.  Pick
+one of the named presets (``"SI"``, ``"SI-N-mm"``, ``"US-ft"``, ``"US-in"``,
+``"none"``), set it globally with :func:`set_units`, or pass ``units=`` to any
+plotting method to override it for a single figure.  Build a custom
+:class:`UnitSystem` for anything else.
+
+The default is SI with kN and m (``"SI"``), matching PyCBA's historical plot
+labels, so existing scripts and figures are unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+
+@dataclass(frozen=True)
+class UnitSystem:
+    """
+    A display unit system: axis-label units and the deflection display scale.
+
+    Holds only label strings and a deflection display factor - it is purely a
+    presentation aid and never affects the analysis (PyCBA does no unit
+    conversion).
+
+    Parameters
+    ----------
+    name : str
+        Human-readable identifier (e.g. ``"SI (kN, m)"``).
+    force : str
+        Force unit label, e.g. ``"kN"`` (used for shear, reactions, loads).
+    length : str
+        Length unit label, e.g. ``"m"`` (used for the distance axis).
+    moment : str
+        Moment unit label, e.g. ``"kNm"`` (conventions vary, so it is given
+        explicitly rather than composed from force x length).
+    distributed : str
+        Distributed-load unit label, e.g. ``"kN/m"``.
+    disp_label : str
+        Unit shown on the deflection axis, e.g. ``"mm"``.
+    disp_scale : float
+        Factor the native deflection is multiplied by for display.  For SI
+        (kN, m) this is ``1000`` (m shown as mm); for a system whose length
+        unit already matches the deflection unit it is ``1``.
+    """
+
+    name: str
+    force: str = ""
+    length: str = ""
+    moment: str = ""
+    distributed: str = ""
+    disp_label: str = ""
+    disp_scale: float = 1.0
+
+    # --- label helpers ------------------------------------------------- #
+    @staticmethod
+    def _suffix(unit: str) -> str:
+        return f" ({unit})" if unit else ""
+
+    @property
+    def moment_axis(self) -> str:
+        return "Bending Moment" + self._suffix(self.moment)
+
+    @property
+    def shear_axis(self) -> str:
+        return "Shear Force" + self._suffix(self.force)
+
+    @property
+    def deflection_axis(self) -> str:
+        return "Deflection" + self._suffix(self.disp_label)
+
+    @property
+    def distance_axis(self) -> str:
+        return "Distance along beam" + self._suffix(self.length)
+
+    def length_axis(self, what: str = "Distance along beam") -> str:
+        """Axis label for a length quantity, e.g. ``length_axis("Position")``."""
+        return what + self._suffix(self.length)
+
+    # --- inline value formatting (load annotations) -------------------- #
+    @staticmethod
+    def _val(value: str, unit: str) -> str:
+        return f"{value} {unit}" if unit else value
+
+    def fmt_force(self, value: float) -> str:
+        return self._val(f"{value:g}", self.force)
+
+    def fmt_moment(self, value: float) -> str:
+        return self._val(f"{value:g}", self.moment)
+
+    def fmt_distributed(self, w0: float, w1: Optional[float] = None) -> str:
+        """Format a (possibly varying) distributed load, e.g. ``5→8 kN/m``."""
+        if w1 is None or w1 == w0:
+            body = f"{w0:g}"
+        else:
+            body = f"{w0:g}→{w1:g}"
+        return self._val(body, self.distributed)
+
+
+# --------------------------------------------------------------------------- #
+# Named presets
+# --------------------------------------------------------------------------- #
+SI = UnitSystem(
+    name="SI (kN, m)",
+    force="kN",
+    length="m",
+    moment="kNm",
+    distributed="kN/m",
+    disp_label="mm",
+    disp_scale=1000.0,
+)
+
+SI_N_MM = UnitSystem(
+    name="SI (N, mm)",
+    force="N",
+    length="mm",
+    moment="N·mm",
+    distributed="N/mm",
+    disp_label="mm",
+    disp_scale=1.0,
+)
+
+US_KIP_FT = UnitSystem(
+    name="US (kip, ft)",
+    force="kip",
+    length="ft",
+    moment="kip·ft",
+    distributed="kip/ft",
+    disp_label="in",
+    disp_scale=12.0,
+)
+
+US_KIP_IN = UnitSystem(
+    name="US (kip, in)",
+    force="kip",
+    length="in",
+    moment="kip·in",
+    distributed="kip/in",
+    disp_label="in",
+    disp_scale=1.0,
+)
+
+NONE = UnitSystem(name="dimensionless")
+
+# Friendly aliases -> preset (keys are normalised: lower-case, spaces/underscores
+# collapsed to hyphens).  EU and AUS practice both use SI kN-m.
+_REGISTRY = {
+    "si": SI,
+    "kn-m": SI,
+    "knm": SI,
+    "eu": SI,
+    "aus": SI,
+    "metric": SI,
+    "si-n-mm": SI_N_MM,
+    "n-mm": SI_N_MM,
+    "nmm": SI_N_MM,
+    "us": US_KIP_FT,
+    "us-ft": US_KIP_FT,
+    "kip-ft": US_KIP_FT,
+    "us-customary": US_KIP_FT,
+    "us-in": US_KIP_IN,
+    "kip-in": US_KIP_IN,
+    "none": NONE,
+    "dimensionless": NONE,
+    "": NONE,
+}
+
+_default: UnitSystem = SI
+
+
+def _normalise(name: str) -> str:
+    return name.strip().lower().replace("_", "-").replace(" ", "-")
+
+
+def set_units(units: Union[str, UnitSystem]) -> UnitSystem:
+    """
+    Set the global default display unit system used by plots.
+
+    Parameters
+    ----------
+    units : str or UnitSystem
+        A preset name (e.g. ``"SI"``, ``"US-ft"``, ``"N-mm"``, ``"none"``) or a
+        :class:`UnitSystem` instance.
+
+    Returns
+    -------
+    UnitSystem
+        The resolved unit system now in effect.
+    """
+    global _default
+    _default = resolve(units)
+    return _default
+
+
+def get_units() -> UnitSystem:
+    """Return the current global default display unit system."""
+    return _default
+
+
+def resolve(units: Optional[Union[str, UnitSystem]] = None) -> UnitSystem:
+    """
+    Resolve a units argument to a :class:`UnitSystem`.
+
+    ``None`` returns the global default (see :func:`set_units`); a string is
+    looked up among the presets (case-insensitive); a :class:`UnitSystem` is
+    returned unchanged.
+
+    Raises
+    ------
+    KeyError
+        If ``units`` is an unknown preset name.
+    """
+    if units is None:
+        return _default
+    if isinstance(units, UnitSystem):
+        return units
+    key = _normalise(units)
+    try:
+        return _REGISTRY[key]
+    except KeyError:
+        raise KeyError(
+            f"Unknown unit system {units!r}. Known presets: "
+            + ", ".join(sorted({k for k in _REGISTRY if k}))
+        )

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Tests for the display unit-system layer (labels and deflection scaling)."""
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import pycba as cba
+from pycba import units as U
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_units():
+    # Keep the global default from leaking between tests.
+    saved = U.get_units()
+    yield
+    U.set_units(saved)
+
+
+def _analysed_beam():
+    L = [5.0, 6.0]
+    EI = 1e8 * np.ones(len(L))
+    R = [-1, 0, -1, 0, -1, 0]
+    ba = cba.BeamAnalysis(L, EI, R, LM=[[1, 1, 20, 0, 0], [2, 2, 50, 3]])
+    ba.analyze()
+    return ba
+
+
+def test_default_is_si_kn_m():
+    assert U.get_units() is U.SI
+    assert U.SI.moment_axis == "Bending Moment (kNm)"
+    assert U.SI.shear_axis == "Shear Force (kN)"
+    assert U.SI.deflection_axis == "Deflection (mm)"
+    assert U.SI.distance_axis == "Distance along beam (m)"
+    assert U.SI.disp_scale == 1000.0
+
+
+def test_resolve_aliases_case_insensitive():
+    assert U.resolve("SI") is U.SI
+    assert U.resolve("eu") is U.SI
+    assert U.resolve("AUS") is U.SI
+    assert U.resolve("US") is U.US_KIP_FT
+    assert U.resolve("us-ft") is U.US_KIP_FT
+    assert U.resolve("Kip-In") is U.US_KIP_IN
+    assert U.resolve("N-mm") is U.SI_N_MM
+    assert U.resolve("none") is U.NONE
+    assert U.resolve(None) is U.get_units()
+    assert U.resolve(U.US_KIP_FT) is U.US_KIP_FT
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(KeyError):
+        U.resolve("furlongs")
+
+
+def test_none_drops_unit_suffixes_and_value_units():
+    assert U.NONE.moment_axis == "Bending Moment"
+    assert U.NONE.deflection_axis == "Deflection"
+    assert U.NONE.distance_axis == "Distance along beam"
+    assert U.NONE.fmt_force(50) == "50"
+    assert U.NONE.fmt_distributed(5, 8) == "5→8"
+
+
+def test_value_formatting():
+    assert U.SI.fmt_force(50) == "50 kN"
+    assert U.SI.fmt_moment(30) == "30 kNm"
+    assert U.SI.fmt_distributed(20) == "20 kN/m"
+    assert U.SI.fmt_distributed(5, 5) == "5 kN/m"
+    assert U.SI.fmt_distributed(5, 8) == "5→8 kN/m"
+    assert U.US_KIP_FT.fmt_force(3.5) == "3.5 kip"
+
+
+def test_set_units_global_default():
+    cba.set_units("US-ft")
+    assert U.get_units() is U.US_KIP_FT
+    ba = _analysed_beam()
+    fig, axs = ba.plot_results(show=False)
+    assert axs[1].get_ylabel() == "Bending Moment (kip·ft)"
+    assert axs[3].get_ylabel() == "Deflection (in)"
+    plt.close(fig)
+
+
+def test_per_plot_override_beats_global():
+    cba.set_units("SI")
+    ba = _analysed_beam()
+    fig, axs = ba.plot_results(show=False, units="none")
+    assert axs[1].get_ylabel() == "Bending Moment"
+    assert axs[3].get_xlabel() == "Distance along beam"
+    plt.close(fig)
+
+
+def test_deflection_scale_applied():
+    ba = _analysed_beam()
+    fig_si, axs_si = ba.plot_results(show=False, units="SI")
+    fig_nm, axs_nm = ba.plot_results(show=False, units="N-mm")
+    # deflection trace is the 2nd line on the deflection panel (after the beam line)
+    d_si = axs_si[3].lines[1].get_ydata()
+    d_nm = axs_nm[3].lines[1].get_ydata()
+    nz = np.abs(d_nm) > 1e-12
+    # SI shows native×1000 (mm), N-mm shows native×1 -> ratio 1000
+    assert np.allclose(d_si[nz] / d_nm[nz], 1000.0)
+    plt.close(fig_si)
+    plt.close(fig_nm)
+
+
+def test_render_load_labels_follow_units():
+    beam = cba.BeamAnalysis([6.0], 1e8, [-1, 0, -1, 0], LM=[[1, 1, 20]]).beam
+    assert "kN/m" in beam.to_tikz(units="SI")
+    us = beam.to_tikz(units="US-ft")
+    assert "kip/ft" in us and "kN/m" not in us
+
+
+def test_bridge_plot_static_labels_follow_units():
+    L = [20.0, 25.0]
+    EI = 30e11 * 1e-6 * np.ones(len(L))
+    R = [-1, 0, -1, 0, -1, 0]
+    ba = cba.BridgeAnalysis(
+        cba.BeamAnalysis(L, EI, R), cba.Vehicle([1.5, 1.5], [60, 60, 60])
+    )
+    fig, axs = ba.plot_static(20.0, units="US-ft")
+    assert axs[1].get_ylabel() == "Bending Moment (kip·ft)"
+    # vehicle caption uses the force unit
+    caption = [t.get_text() for t in axs[0].texts if "Vehicle:" in t.get_text()][0]
+    assert "kip" in caption and "kN" not in caption
+    plt.close(fig)


### PR DESCRIPTION
Stacked on #147. Adds a display unit-system layer so plots can be labelled (and deflections scaled) for SI / US-customary / etc., **without** changing PyCBA's unit-agnostic solver — no conversions are added to the analysis.

### Key idea
PyCBA's computation already does no unit conversion. Units only surface in plot labels and one display scale (deflection ×1000 → mm). So this is purely a labelling layer; the numbers entering and leaving the solver are untouched.

### What's added
- **`pycba.units` module** — a frozen `UnitSystem` (force/length/moment/distributed label strings + a deflection display scale/label) with presets:

  | Name | Force | Length | Moment | Deflection |
  | --- | --- | --- | --- | --- |
  | `SI` *(default; EU/AUS)* | kN | m | kNm | mm (×1000) |
  | `SI-N-mm` | N | mm | N·mm | mm (×1) |
  | `US-ft` *(US)* | kip | ft | kip·ft | in (×12) |
  | `US-in` | kip | in | kip·in | in (×1) |
  | `none` | — | — | — | — (no labels) |

  Friendly aliases resolve case-insensitively; unknown names raise `KeyError`.
- **`pycba.set_units(...)` / `get_units()`** set the global default; **every plotting method gains a `units=` override** (preset name or a `UnitSystem`). Build a custom `UnitSystem` for anything else.
- **Default stays SI kN–m**, so existing scripts, notebooks, and the committed figures are unchanged.
- Threaded through `plot_results`, `Beam.plot`/`plot_beam` + the matplotlib & TikZ renderers (load labels), `BridgeAnalysis.plot_static`/`animate`/`plot_envelopes`/`plot_ratios` + the vehicle caption, `Envelopes.plot`, `InfluenceLines.plot_il`, and the nonlinear plots.

### Docs & tests
- A "Units" section on the Defining Beams page (preset table, `set_units`/`units=`, custom systems); `pycba.units` registered in the API reference.
- `test_units.py`: presets, aliases, global vs per-plot override, deflection scaling, label propagation through render + bridge plots.
- Full suite: **185 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)