### PR TITLE
Detect mechanisms with a stability check before solving

### DIFF
--- a/docs/source/general.md
+++ b/docs/source/general.md
@@ -83,8 +83,12 @@ ba = cba.BeamAnalysis([10.0], 30e4, R=[-1, 0, 0, 0])  # pin one end, free the ot
 ba.analyze()      # ValueError: Structure is geometrically unstable ... mechanism
 ```
 
-This catches both insufficient supports and over-released internal hinges. For
-an unusual but intentionally near-singular model you can skip the check with
+This catches both insufficient supports and over-released internal hinges. You
+can also test a model up front, without solving, via `ba.is_stable()` (which
+returns a `bool` instead of raising). The result is cached per structure, so
+looped analyses that vary only the loads (e.g. a moving-load run) incur the
+check only once; it is re-evaluated only if the beam structure changes. For an
+unusual but intentionally near-singular model you can skip it entirely with
 `ba.analyze(check_stability=False)`.
 
 ## Load Matrix (`LM`)

--- a/docs/source/general.md
+++ b/docs/source/general.md
@@ -72,6 +72,21 @@ Supports with a stiffness (kN/m or kNm/rad) are indicated by a positive value of
 
 **Units**: kN/m or kNm/rad or None
 
+If the restraints leave the structure under-supported, it is a *mechanism* —
+the stiffness matrix is singular and the solution is meaningless. Before
+solving, `analyze()` checks the free-DOF stiffness for this condition and
+raises a clear `ValueError` rather than returning enormous, spurious
+displacements:
+
+```python
+ba = cba.BeamAnalysis([10.0], 30e4, R=[-1, 0, 0, 0])  # pin one end, free the other
+ba.analyze()      # ValueError: Structure is geometrically unstable ... mechanism
+```
+
+This catches both insufficient supports and over-released internal hinges. For
+an unusual but intentionally near-singular model you can skip the check with
+`ba.analyze(check_stability=False)`.
+
 ## Load Matrix (`LM`)
 
 A `List` of `Lists` representing the applied loads.

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -314,7 +314,7 @@ class BeamAnalysis:
             load = [i_span, 5, w1, w2]
         self._beam.add_load(load)
 
-    def analyze(self, npts: Optional[int] = None) -> int:
+    def analyze(self, npts: Optional[int] = None, check_stability: bool = True) -> int:
         """
         Execute the direct-stiffness analysis.
 
@@ -330,6 +330,11 @@ class BeamAnalysis:
             Number of evaluation points along each member for computing
             distributed load effects (bending moment, shear, deflection).
             Must be greater than 3; defaults to 100 if omitted or ``≤ 3``.
+        check_stability : bool, optional
+            If ``True`` (default), check the assembled stiffness for a
+            mechanism before solving and raise a clear error (see
+            :meth:`_check_stability`).  Set ``False`` to skip the check for an
+            unusual but intentionally near-singular model.
 
         Returns
         -------
@@ -340,7 +345,8 @@ class BeamAnalysis:
         ------
         ValueError
             If the model is invalid (see :meth:`_validate`) or if the
-            structure is geometrically unstable (see :meth:`_solver`).
+            structure is geometrically unstable (see :meth:`_check_stability`
+            and :meth:`_solver`).
         """
         if npts and npts > 3:
             self.npts = npts
@@ -353,6 +359,8 @@ class BeamAnalysis:
 
         f = np.copy(fU)
         ksysU = self._assemble()
+        if check_stability:
+            self._check_stability(ksysU, restraints, d_presc)
         ksys = np.copy(ksysU)
         ksys, f = self._apply_bc(ksys, f)
         d = self._solver(ksys, f)
@@ -360,6 +368,66 @@ class BeamAnalysis:
 
         self._beam_results = BeamResults(self._beam, d, r, self.npts, rs)
         return 0
+
+    # Reciprocal-condition-number floor for the free-DOF stiffness partition.
+    # True mechanisms sit near machine epsilon (~1e-16); legitimately flexible
+    # structures stay well above this, so 1e-12 separates them with margin.
+    _STABILITY_RCOND = 1e-12
+
+    def _check_stability(
+        self, ksysU: np.ndarray, restraints: list, d_presc: list
+    ) -> None:
+        """
+        Detect a mechanism (near-singular structure) before solving.
+
+        Direct elimination puts ``1.0`` on the diagonal of constrained DOFs,
+        which pollutes the condition number of the reduced system, so this
+        works instead on the **free-DOF partition** of the *unrestricted*
+        stiffness matrix - the block that actually governs the unknown
+        displacements.  Excluded DOFs are those that are fully fixed
+        (``restraints < 0``) or carry a prescribed displacement; spring DOFs
+        remain free and contribute their stiffness.
+
+        For a stable linear-elastic structure this partition is symmetric
+        positive-definite.  A mechanism (insufficient restraint, or an
+        over-released internal hinge) makes it singular: its smallest
+        eigenvalue collapses to zero relative to the largest.  The reciprocal
+        condition number ``min|λ| / max|λ|`` is therefore compared against
+        :attr:`_STABILITY_RCOND`; a value below it indicates a mechanism.
+
+        Parameters
+        ----------
+        ksysU : np.ndarray, shape (nDOF, nDOF)
+            Unrestricted global stiffness matrix (including spring terms).
+        restraints : list
+            Beam restraint vector (same as ``R``).
+        d_presc : list
+            Prescribed-displacement vector (``None`` entries = free DOFs).
+
+        Raises
+        ------
+        ValueError
+            If the free-DOF stiffness partition is singular to within
+            :attr:`_STABILITY_RCOND`, i.e. the structure is a mechanism.
+        """
+        free = [
+            i
+            for i in range(self._nDOF)
+            if not (restraints[i] < 0 or d_presc[i] is not None)
+        ]
+        if not free:
+            return  # fully constrained: nothing to solve, trivially stable
+
+        kff = ksysU[np.ix_(free, free)]
+        ev = np.abs(np.linalg.eigvalsh(kff))
+        ev_max = ev.max()
+        if ev_max == 0.0 or (ev.min() / ev_max) < self._STABILITY_RCOND:
+            raise ValueError(
+                "Structure is geometrically unstable: the free-DOF stiffness "
+                "is singular, indicating a mechanism (e.g. insufficient support "
+                "restraints or an over-released internal hinge). Add restraint, "
+                "or pass analyze(check_stability=False) to override this check."
+            )
 
     def _forces(self) -> np.ndarray:
         """

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -148,6 +148,10 @@ class BeamAnalysis:
         self._n = self._beam.no_spans
         self._no_nodes = self._n + 1
         self._nDOF = 2 * self._no_nodes
+        # Beam structure_version at the last successful stability check, so the
+        # check is not repeated across looped analyses (e.g. a moving load)
+        # unless the structure itself changes.  ``None`` = never checked.
+        self._checked_version = None
 
     @property
     def beam_results(self) -> BeamResults:
@@ -333,8 +337,12 @@ class BeamAnalysis:
         check_stability : bool, optional
             If ``True`` (default), check the assembled stiffness for a
             mechanism before solving and raise a clear error (see
-            :meth:`_check_stability`).  Set ``False`` to skip the check for an
-            unusual but intentionally near-singular model.
+            :meth:`is_stable` / :meth:`_check_stability`).  Set ``False`` to
+            skip the check for an unusual but intentionally near-singular
+            model.  The check runs at most once per structure: its result is
+            cached and only re-evaluated if the beam structure changes, so it
+            adds no cost to looped analyses (e.g. a moving load) that vary
+            only the loads.
 
         Returns
         -------
@@ -359,8 +367,9 @@ class BeamAnalysis:
 
         f = np.copy(fU)
         ksysU = self._assemble()
-        if check_stability:
+        if check_stability and self._checked_version != self._beam.structure_version:
             self._check_stability(ksysU, restraints, d_presc)
+            self._checked_version = self._beam.structure_version
         ksys = np.copy(ksysU)
         ksys, f = self._apply_bc(ksys, f)
         d = self._solver(ksys, f)
@@ -428,6 +437,31 @@ class BeamAnalysis:
                 "restraints or an over-released internal hinge). Add restraint, "
                 "or pass analyze(check_stability=False) to override this check."
             )
+
+    def is_stable(self) -> bool:
+        """
+        Return whether the structure is stable (not a mechanism).
+
+        Runs the same free-DOF stability check as :meth:`analyze` but returns a
+        boolean instead of raising, so the model can be validated up front
+        without solving.  A ``True`` result is cached (keyed on the beam's
+        :attr:`~pycba.beam.Beam.structure_version`), so a subsequent
+        ``analyze()`` does not repeat the check unless the structure changes.
+
+        Returns
+        -------
+        bool
+            ``True`` if the free-DOF stiffness partition is non-singular to
+            within :attr:`_STABILITY_RCOND`, otherwise ``False``.
+        """
+        restraints = self._beam.restraints
+        d_presc = self._beam.prescribed_displacements
+        try:
+            self._check_stability(self._assemble(), restraints, d_presc)
+        except ValueError:
+            return False
+        self._checked_version = self._beam.structure_version
+        return True
 
     def _forces(self) -> np.ndarray:
         """

--- a/src/pycba/beam.py
+++ b/src/pycba/beam.py
@@ -58,6 +58,10 @@ class Beam:
         self._loads = []
         self.LM = []
         self._terminal_coords = [0.0]
+        # Bumped on any change to the *structure* (geometry, rigidity,
+        # restraints, prescribed displacements) so a cached stability check can
+        # be invalidated.  Load changes deliberately do not bump it.
+        self._structure_version = 0
 
         if L is not None and eletype is not None:
             # A single rigidity (scalar EI, or one SectionEI) applies to all
@@ -114,6 +118,7 @@ class Beam:
         self._no_spans = len(self.mbr_lengths)
         self._length += L
         self._terminal_coords.append(self._terminal_coords[-1] + L)
+        self._structure_version += 1
 
     @property
     def loads(self) -> LoadMatrix:
@@ -213,7 +218,18 @@ class Beam:
 
         """
         self._restraints = r
-        pass
+        self._structure_version += 1
+
+    @property
+    def structure_version(self) -> int:
+        """
+        int : A counter that increments whenever the beam *structure* changes.
+
+        Bumped by changes to geometry, rigidity, restraints or prescribed
+        displacements (but not loads).  Used to invalidate a cached stability
+        check (see :meth:`pycba.analysis.BeamAnalysis.is_stable`).
+        """
+        return self._structure_version
 
     @property
     def prescribed_displacements(self) -> list:
@@ -248,6 +264,7 @@ class Beam:
                 f"D must have same length as R ({len(self._restraints)}), got {len(d)}"
             )
         self._prescribed_displacements = d
+        self._structure_version += 1
 
     def _set_element_type(self, i_span):
         """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1045,3 +1045,49 @@ def test_check_stability_can_be_disabled():
     ba2 = cba.BeamAnalysis(L, EI, R, LM)
     assert ba2.analyze(check_stability=False) == 0
     assert np.all(np.isfinite(ba2.beam_results.D))
+
+
+def test_stability_check_cached_across_load_changes():
+    """
+    The stability check is load-independent, so it must run only once across
+    a load-only loop (e.g. a moving-load analysis), not every solve.
+    """
+    ba = cba.BeamAnalysis([7.5, 7.0], 30 * 600e7 * 1e-6, [-1, 0, -1, 0, -1, 0])
+    calls = {"n": 0}
+    orig = ba._check_stability
+    ba._check_stability = lambda *a, **k: (calls.__setitem__("n", calls["n"] + 1), orig(*a, **k))[1]
+
+    for w in (10, 20, 30, 40):
+        ba.set_loads([[1, 1, w], [2, 1, w]])
+        assert ba.analyze() == 0
+    assert calls["n"] == 1
+
+
+def test_structure_version_invalidates_cached_check():
+    """
+    Load edits leave the structure_version (and the cached check) untouched;
+    a restraint edit bumps it and forces a re-check on the next analyze.
+    """
+    ba = cba.BeamAnalysis([7.5, 7.0], 30 * 600e7 * 1e-6, [-1, 0, -1, 0, -1, 0])
+    ba.analyze()
+    v = ba.beam.structure_version
+
+    ba.set_loads([[1, 1, 99]])
+    ba.add_udl(2, 5.0)
+    assert ba.beam.structure_version == v  # loads do not invalidate
+
+    # Remove interior + end vertical restraints -> now a mechanism
+    ba.beam.restraints = [-1, 0, 0, 0, 0, 0]
+    assert ba.beam.structure_version != v  # structural edit invalidates
+    with pytest.raises(ValueError, match="geometrically unstable"):
+        ba.analyze()
+
+
+def test_is_stable_predicate():
+    """is_stable() returns a bool (no raise) and primes the cached check."""
+    stable = cba.BeamAnalysis([10.0], 30 * 600e7 * 1e-6, [-1, 0, -1, 0])
+    assert stable.is_stable() is True
+    assert stable._checked_version == stable.beam.structure_version
+
+    mech = cba.BeamAnalysis([10.0], 30 * 600e7 * 1e-6, [-1, 0, 0, 0])
+    assert mech.is_stable() is False

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -995,3 +995,53 @@ def test_unstable_structure_error():
     ba = cba.BeamAnalysis(L, EI, R, LM)
     with pytest.raises(ValueError, match="geometrically unstable"):
         ba.analyze()
+
+
+def test_mechanism_pin_free_raises():
+    """
+    A pin-free span (rotates about the pin) is a mechanism. The stiffness
+    matrix is only *near*-singular, so the solve would otherwise return
+    meaningless ~1e17 displacements; the stability check must catch it
+    before solving (issue #134).
+    """
+    L, EI, R, eType = cba.parse_beam_string("P10F")
+    ba = cba.BeamAnalysis(L, EI, R, [[1, 2, 10, 10]], eType)
+    with pytest.raises(ValueError, match="geometrically unstable"):
+        ba.analyze()
+
+
+def test_stable_lookalikes_not_flagged():
+    """
+    Structures that resemble a mechanism but are restrained must NOT be
+    flagged: an encastre-free cantilever, a propped cantilever, and a beam
+    with a single (legitimate) internal hinge all analyse normally.
+    """
+    for beam_str, lm in [
+        ("E10F", [[1, 2, 10, 10]]),  # cantilever
+        ("E10R", [[1, 1, 10]]),  # propped cantilever
+        ("E20H20R", [[1, 1, 10], [2, 1, 10]]),  # one internal hinge
+    ]:
+        L, EI, R, eType = cba.parse_beam_string(beam_str)
+        ba = cba.BeamAnalysis(L, EI, R, lm, eType)
+        assert ba.analyze() == 0
+        assert np.all(np.isfinite(ba.beam_results.D))
+
+
+def test_check_stability_can_be_disabled():
+    """
+    A very soft spring (1e-8) with a stiff member is solvable but trips the
+    relative-conditioning threshold; ``check_stability=False`` overrides the
+    check and returns the (finite) result.
+    """
+    L = [10.0]
+    EI = 1e8
+    R = [1e-8, 0, -1, 0]  # near-singular but not a true mechanism
+    LM = [[1, 1, 10]]
+
+    ba = cba.BeamAnalysis(L, EI, R, LM)
+    with pytest.raises(ValueError, match="geometrically unstable"):
+        ba.analyze()  # check on by default
+
+    ba2 = cba.BeamAnalysis(L, EI, R, LM)
+    assert ba2.analyze(check_stability=False) == 0
+    assert np.all(np.isfinite(ba2.beam_results.D))


### PR DESCRIPTION
Closes #134.

### Problem
A mechanism (e.g. `P10F` — a pin-free span that rotates about the pin, or an over-released internal hinge) leaves the assembled stiffness matrix only *near*-singular. `np.linalg.solve` then "succeeds" and returns physically meaningless ~1e17 displacements instead of raising — the solver's existing `LinAlgError` backstop only fires on *exact* singularity (e.g. no supports at all).

### Fix
`analyze()` now checks the structure for a mechanism before solving and raises a clear `ValueError("...geometrically unstable...mechanism...")`.

Implementation points that matter:
- **Checks the free-DOF partition `Kff`** of the *unrestricted* stiffness matrix — not the elimination-modified matrix, whose `1.0` diagonals on constrained DOFs pollute its condition number. `Kff` is the block that actually governs the unknown displacements (fixed/prescribed DOFs excluded; spring DOFs kept).
- **Scale-invariant criterion**: a stable elastic `Kff` is symmetric positive-definite; a mechanism makes it singular. The test is the reciprocal condition number `min|λ| / max|λ| < 1e-12` (from `eigvalsh`), so it's independent of the unit system and `EI` magnitude.
- **Escape hatch**: `analyze(check_stability=False)` skips the check for an unusual but intentionally near-singular model.

### Why 1e-12
Measured reciprocal condition numbers separate cleanly: true mechanisms sit at ~1e-17 (machine epsilon), well-conditioned structures at ~0.1–1, and even a pathological stable model (stiff member + 1e-3 spring) stays at ~1e-11. The 1e-12 floor sits in that gap. A model with springs spanning >12 orders of magnitude could false-positive — that's exactly what `check_stability=False` is for.

### Validation
Correctly discriminates the lookalikes:

| Model | Result |
|---|---|
| `P10F` pin–free (the issue's case), no supports, soft spring 1e-8 | **raises** |
| `E10F` cantilever (looks like P10F but fixed end → stable), `E10R` propped cantilever, 3-span, `E20H20R` internal hinge, soft spring 1e-3 | pass |
| soft spring 1e-8 with `check_stability=False` | solves (finite) |

The nonlinear collapse analysis is unaffected — it uses its own `np.linalg.solve`, not `BeamAnalysis.analyze()`. Tests added in `test_basic.py` (mechanism raises, stable lookalikes pass, bypass works); the existing no-supports test still passes. Full suite: **188 passed**. Docs: a note in the Restraints section of the Defining Beams page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)