### PR TITLE
MemberType enum + reaction-envelope extremes

### DIFF
--- a/src/pycba/__init__.py
+++ b/src/pycba/__init__.py
@@ -7,6 +7,7 @@ __version__ = "0.8.0"
 from .analysis import BeamAnalysis
 from .beam import Beam
 from .section import SectionEI
+from .types import MemberType
 from .load import (
     LoadCNL,
     MemberResults,

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -111,13 +111,15 @@ class BeamAnalysis:
                curvature field is ``κ(x) = k0 + k1·x + …`` (e.g. creep,
                shrinkage or thermal curvature).
 
-        eletype : array_like of int, optional
-            Element type for each span, controlling which end(s) carry moment:
+        eletype : array_like, optional
+            Element type for each span, controlling which end(s) carry moment.
+            Each entry may be an integer code, a :class:`~pycba.MemberType`,
+            or its name string (e.g. ``"FP"``):
 
-            1. Fixed–fixed (default).
-            2. Fixed–pinned (moment release at right end).
-            3. Pinned–fixed (moment release at left end).
-            4. Pinned–pinned (moment releases at both ends).
+            1. ``FF`` Fixed–fixed (default).
+            2. ``FP`` Fixed–pinned (moment release at right end).
+            3. ``PF`` Pinned–fixed (moment release at left end).
+            4. ``PP`` Pinned–pinned (moment releases at both ends).
 
             At an internal hinge, only one of the two members meeting at that
             node should have a pinned end.

--- a/src/pycba/beam.py
+++ b/src/pycba/beam.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 import numpy as np
 from scipy import integrate
 from .load import parse_LM, LoadType, LoadMatrix, LoadCNL, LoadIC
+from .types import MemberType
 from .section import SectionEI
 
 
@@ -37,7 +38,9 @@ class Beam:
             The load matrix: a list of loads on the beam; each load with several
             parameters.
         eletype : Optional[np.ndarray]
-            A vector of the member types. Defaults to a fixed-fixed element.
+            A vector of the member types, each an integer code ``1-4``, a
+            :class:`~pycba.MemberType`, or a name string (``"FF"``/``"FP"``/
+            ``"PF"``/``"PP"``). Defaults to a fixed-fixed element.
         D : Optional[np.ndarray]
             A vector of prescribed displacements. Must have same length as R.
             Use None for DOFs without prescribed displacement.
@@ -90,7 +93,7 @@ class Beam:
         if LM is not None:
             self.LM = LM
 
-    def add_span(self, L: float, EI: float, eletype: int):
+    def add_span(self, L: float, EI: float, eletype: Union[int, str, MemberType] = 1):
         """
         Add a span to the continuous beam
 
@@ -100,8 +103,10 @@ class Beam:
             The length of the member.
         EI : np.ndarray
             The flexural rigidity of the member.
-        eletype : int
-            The element type for the member
+        eletype : int, str, or pycba.MemberType
+            The element type for the member, as the integer code ``1-4``, a
+            :class:`~pycba.MemberType` (e.g. ``MemberType.FP``), or its
+            case-insensitive name (e.g. ``"FP"``).  See :class:`~pycba.MemberType`.
 
         Returns
         -------
@@ -114,11 +119,32 @@ class Beam:
             EI.validate_length(L)
         self.mbr_lengths.append(L)
         self.mbr_EIs.append(EI)
-        self.mbr_eletype.append(eletype)
+        self.mbr_eletype.append(MemberType.coerce(eletype))
         self._no_spans = len(self.mbr_lengths)
         self._length += L
         self._terminal_coords.append(self._terminal_coords[-1] + L)
         self._structure_version += 1
+
+    def add_member(
+        self, L: float, EI: float, mbr_type: Union[int, str, MemberType] = MemberType.FF
+    ):
+        """
+        Add a member (span) to the beam, naming its type.
+
+        A friendlier alias of :meth:`add_span` whose ``mbr_type`` accepts a
+        :class:`~pycba.MemberType`, a name string (``"FF"``/``"FP"``/``"PF"``/
+        ``"PP"``), or the integer code ``1-4``.
+
+        Parameters
+        ----------
+        L : float
+            The length of the member.
+        EI : float or pycba.section.SectionEI
+            The flexural rigidity of the member.
+        mbr_type : pycba.MemberType, str, or int
+            The member type / moment-release pattern (default ``FF``).
+        """
+        self.add_span(L, EI, mbr_type)
 
     @property
     def loads(self) -> LoadMatrix:

--- a/src/pycba/bridge.py
+++ b/src/pycba/bridge.py
@@ -842,11 +842,16 @@ class BridgeAnalysis:
         )
         # Check if consistent envelope
         if len(self.pos) == env.Rmax.shape[1]:
-            axsRight = subfigs[1].subplots(nreactions, 1, sharex=True)
+            axsRight = np.atleast_1d(subfigs[1].subplots(nreactions, 1, sharex=True))
+            pos = np.asarray(self.pos)
             for i, ax in enumerate(axsRight):
                 ax.plot([0, L], [0, 0], "k", lw=2)
-                ax.plot(self.pos, env.Rmax[i, :], "r")
-                ax.plot(self.pos, env.Rmin[i, :], "b")
+                ax.plot(pos, env.Rmax[i, :], "r")
+                ax.plot(pos, env.Rmin[i, :], "b")
+                # Mark and label the governing (extreme) reaction values so the
+                # critical magnitude is readable directly off the plot.
+                self._mark_reaction_extreme(ax, pos, env.Rmax[i, :], "r", np.argmax)
+                self._mark_reaction_extreme(ax, pos, env.Rmin[i, :], "b", np.argmin)
                 ax.grid()
                 ax.set_ylabel(f"Reaction {i+1}{react_u}")
             axsRight[-1].set_xlabel(us.length_axis("Position of Front Axle"))
@@ -857,12 +862,42 @@ class BridgeAnalysis:
                 zip(axsRight, ["max", "min"], ["r", "b"])
             ):
                 r = eval(f"env.R{le}val")  # kinda yuk!
-                ax.bar(np.arange(env.nsup), r, color=col)
+                bars = ax.bar(np.arange(env.nsup), r, color=col)
+                # Label each bar with its governing reaction value.
+                ax.bar_label(bars, fmt="%.3g", fontsize=8, padding=2)
                 ax.set_xticks(np.arange(env.nsup))
                 ax.set_xticklabels([f"R{i+1}" for i in range(env.nsup)])
-                ax.set_ylabel(f"Reactions [{le}]")
+                ax.set_ylabel(f"Reactions [{le}]{react_u}")
                 ax.grid()
             axsRight[1].set_xlabel("Reaction ID")
+
+    @staticmethod
+    def _mark_reaction_extreme(ax, pos, series, color, arg_fn):
+        """
+        Mark and annotate the extreme of a reaction time-history on ``ax``.
+
+        ``arg_fn`` is :func:`numpy.argmax` (governing maximum, ``r`` line) or
+        :func:`numpy.argmin` (governing minimum, ``b`` line); a marker is drawn
+        at the extreme and labelled with its value.
+        """
+        series = np.asarray(series)
+        if series.size == 0:
+            return
+        idx = int(arg_fn(series))
+        xv, yv = pos[idx], series[idx]
+        ax.plot([xv], [yv], color=color, marker="o", ms=5, zorder=5)
+        above = arg_fn is np.argmax
+        ax.annotate(
+            f"{yv:.3g}",
+            (xv, yv),
+            textcoords="offset points",
+            xytext=(0, 5 if above else -5),
+            ha="center",
+            va="bottom" if above else "top",
+            fontsize=8,
+            color=color,
+            fontweight="bold",
+        )
 
     def plot_ratios(self, env_ratios: Dict[str, np.ndarray], units=None):
         """

--- a/src/pycba/types.py
+++ b/src/pycba/types.py
@@ -2,12 +2,69 @@
 PyCBA - Shared type definitions
 """
 from __future__ import annotations
+import enum
 from typing import List, Union, NamedTuple, Optional, Tuple
 import numpy as np
 
 
 LoadType = List[Union[int, float]]
 LoadMatrix = List[LoadType]
+
+
+class MemberType(enum.IntEnum):
+    """
+    Beam member (element) type, encoding the internal moment releases.
+
+    The value is the integer ``eletype`` used throughout PyCBA, so a member
+    type may be passed anywhere an ``eletype`` is accepted (it *is* an int).
+    The two letters read left end then right end (``F`` = fixed/continuous,
+    ``P`` = pinned/released):
+
+    * ``FF`` (1) - fixed-fixed: moment continuous at both ends (the default).
+    * ``FP`` (2) - fixed-pinned: moment released at the right end.
+    * ``PF`` (3) - pinned-fixed: moment released at the left end.
+    * ``PP`` (4) - pinned-pinned: moment released at both ends.
+
+    At an internal hinge only one of the two members meeting at the node
+    should carry the release.
+    """
+
+    FF = 1
+    FP = 2
+    PF = 3
+    PP = 4
+
+    @classmethod
+    def coerce(cls, value: Union["MemberType", int, str]) -> int:
+        """
+        Normalise a member type to its integer ``eletype``.
+
+        Accepts a :class:`MemberType`, an ``int`` (1-4), or a case-insensitive
+        name string (``"FF"``, ``"FP"``, ``"PF"``, ``"PP"``).
+
+        Raises
+        ------
+        ValueError
+            If a string is not a recognised member-type name, or an int is
+            outside ``1-4``.
+        """
+        if isinstance(value, str):
+            try:
+                return int(cls[value.strip().upper()])
+            except KeyError:
+                names = ", ".join(m.name for m in cls)
+                raise ValueError(
+                    f"Unknown member type {value!r}; use one of {names} (or 1-4)."
+                )
+        # MemberType, a Python/NumPy scalar, or a 1-element array (the default
+        # eletype is np.ones((N, 1)), so each entry arrives as a length-1 row).
+        arr = np.asarray(value)
+        if arr.size != 1:
+            raise ValueError(f"A single member type is required, got {arr.size} values.")
+        iv = int(arr.reshape(-1)[0])
+        if iv not in (1, 2, 3, 4):
+            raise ValueError(f"eletype must be 1-4 (or a MemberType/name), got {iv}.")
+        return iv
 
 
 class LoadCNL(NamedTuple):

--- a/tests/test_member_type.py
+++ b/tests/test_member_type.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Tests for the MemberType enum and friendlier element-type API."""
+
+import enum
+import numpy as np
+import pytest
+import pycba as cba
+
+
+def test_membertype_is_int_enum_with_codes():
+    assert issubclass(cba.MemberType, enum.IntEnum)
+    assert (int(cba.MemberType.FF), int(cba.MemberType.FP),
+            int(cba.MemberType.PF), int(cba.MemberType.PP)) == (1, 2, 3, 4)
+
+
+def test_coerce_accepts_int_enum_and_name():
+    assert cba.MemberType.coerce(2) == 2
+    assert cba.MemberType.coerce(cba.MemberType.FP) == 2
+    assert cba.MemberType.coerce("FP") == 2
+    assert cba.MemberType.coerce("fp") == 2  # case-insensitive
+    assert cba.MemberType.coerce(np.array([3.0])) == 3  # default eletype row shape
+
+
+def test_coerce_rejects_bad_values():
+    with pytest.raises(ValueError, match="Unknown member type"):
+        cba.MemberType.coerce("XX")
+    with pytest.raises(ValueError, match="eletype must be 1-4"):
+        cba.MemberType.coerce(7)
+
+
+def _Ma(eletype):
+    """Hogging moment at the fixed end of a fixed-pinned span under a central PL."""
+    P, L, EI = 10.0, 10.0, 30 * 600e7 * 1e-6
+    ba = cba.BeamAnalysis([L], EI, [-1, -1, -1, -1], [[1, 2, P, 0.5 * L, 0]],
+                          eletype=eletype)
+    ba.analyze()
+    return ba.beam_results.results.M[1], ba.beam.mbr_eletype
+
+
+def test_eletype_forms_are_equivalent():
+    m_int, e_int = _Ma([2])
+    m_enum, e_enum = _Ma([cba.MemberType.FP])
+    m_str, e_str = _Ma(["FP"])
+    assert m_int == pytest.approx(-3 * 10.0 * 10.0 / 16)  # -3PL/16
+    assert m_enum == pytest.approx(m_int)
+    assert m_str == pytest.approx(m_int)
+    # stored as plain ints regardless of the input form
+    assert e_int == e_enum == e_str == [2]
+    assert all(isinstance(x, int) for x in e_str)
+
+
+def test_default_eletype_still_works():
+    ba = cba.BeamAnalysis([5.0, 6.0], 1e8, [-1, 0, -1, 0, -1, 0],
+                          [[1, 1, 10], [2, 1, 10]])
+    assert ba.analyze() == 0
+    assert ba.beam.mbr_eletype == [1, 1]
+
+
+def test_add_member_friendly_api():
+    beam = cba.Beam()
+    out = beam.add_member(5.0, 1e8, "PP")
+    beam.add_member(6.0, 1e8, cba.MemberType.FF)
+    beam.add_member(4.0, 1e8)  # default FF
+    assert beam.mbr_eletype == [4, 1, 1]
+    assert out is None  # add_member mirrors add_span (no return)

--- a/tests/test_reaction_envelope.py
+++ b/tests/test_reaction_envelope.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Tests for the reaction-envelope plotting improvements (extreme markers)."""
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pycba as cba
+
+
+def _bridge(spans=(20.0, 25.0, 20.0)):
+    L = list(spans)
+    EI = 30e11 * 1e-6 * np.ones(len(L))
+    R = [-1, 0] * (len(L) + 1)
+    bridge = cba.BeamAnalysis(L, EI, R)
+    return cba.BridgeAnalysis(bridge, cba.Vehicle([1.2, 1.2], [60, 60, 60]))
+
+
+def test_mark_reaction_extreme_adds_marker_and_label():
+    fig, ax = plt.subplots()
+    pos = np.linspace(0.0, 10.0, 11)
+    series = np.array([0, 1, 2, 9, 4, 3, 2, 1, 0, 0, 0], dtype=float)  # peak 9 @ idx 3
+    cba.BridgeAnalysis._mark_reaction_extreme(ax, pos, series, "r", np.argmax)
+    # a marker line at the extreme
+    markers = [ln for ln in ax.lines if ln.get_marker() == "o"]
+    assert markers and markers[0].get_xydata()[0][1] == 9.0
+    # a value annotation "9"
+    assert any("9" in t.get_text() for t in ax.texts)
+    plt.close(fig)
+
+
+def test_plot_envelopes_consistent_path_runs_and_marks():
+    ba = _bridge()
+    env = ba.run_vehicle(2.0)
+    ba.plot_envelopes(env)  # consistent path (pos length == Rmax columns)
+    # the figure now exists with marked reaction axes; just assert no error and
+    # that some axes carry the 'o' extreme markers
+    fig = plt.gcf()
+    has_markers = any(
+        ln.get_marker() == "o" for axx in fig.get_axes() for ln in axx.lines
+    )
+    assert has_markers
+    plt.close("all")
+
+
+def test_plot_envelopes_incompatible_bar_path_runs():
+    ba = _bridge(spans=(20.0, 25.0))
+    e1 = ba.run_vehicle(1.0)
+    e2 = ba.run_vehicle(2.5)
+    envenv = cba.Envelopes.zero_like(e1)
+    envenv.augment(e1)
+    envenv.augment(e2)
+    # incompatible reaction shape -> bar (envelope-of-envelopes) path with labels
+    ba.plot_envelopes(envenv)
+    plt.close("all")


### PR DESCRIPTION
Two small, additive ergonomics improvements answering the roadmap questions on enums and reaction-envelope plotting (#4).

## 1. `MemberType` enum + friendlier element types (roadmap #4, #2)
Element types were bare magic ints (`eletype=[2]`). Now:
- New **`MemberType`** `IntEnum` — `FF`/`FP`/`PF`/`PP` = 1–4 (it *is* an int, so usable anywhere an `eletype` is).
- `eletype` accepts a `MemberType`, a name string (`"FP"`, case-insensitive), or the int — normalised via `MemberType.coerce()`.
- **`Beam.add_member(L, EI, mbr_type=...)`** — the friendlier alias the roadmap asked for.
- **Strictly backward-compatible:** existing int/array `eletype` (incl. the default `np.ones((N,1))`) is unchanged; entries are stored as plain ints. `eletype=[2]`, `[MemberType.FP]`, and `["FP"]` give the identical analysis (verified ⇒ `-3PL/16`).

> On *load*-type enums: I deliberately skipped them — the `add_udl/add_pl/…` helpers already hide the type codes, and the name `LoadType` is already a type alias, so a load enum is low-value and awkward.

## 2. Reaction-envelope extremes (issue #8, roadmap reaction-plot item)
`plot_envelopes` now **indicates the extremes** (the "note for future" on #8): a marker + value label at each support's governing max/min on the per-position time-histories, and value labels on the bars in the incompatible envelope-of-envelopes path. (Reaction axis labels already follow the unit system from the units work.)

## Tests
`tests/test_member_type.py`, `tests/test_reaction_envelope.py` added. Verified in an isolated worktree against the suites most affected by the change — **186 passed** (basic, bridge, render, units, member_type, reaction_envelope, additive_pattern, nonprismatic, results). Full-suite confirmation pending (sequenced after the concurrent LoadPattern run to avoid CPU thrash).

Formatting deferred to the repo's `action-black` bot (local black version skews from the repo's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)