### PR TITLE
Add named `supports=` API for specifying restraints

### DIFF
--- a/docs/source/general.md
+++ b/docs/source/general.md
@@ -72,6 +72,49 @@ Supports with a stiffness (kN/m or kNm/rad) are indicated by a positive value of
 
 **Units**: kN/m or kNm/rad or None
 
+(named-supports)=
+### Named supports (`supports`)
+
+Writing `R` by hand means tracking two DOFs per node and the `-1`/`0`/`+k`
+convention. As a friendlier alternative, pass `supports=` instead of `R=` — a
+list with **one entry per node** (left to right), each naming the support there:
+
+| Name(s) | Meaning | Lowers to `[vertical, rotation]` |
+|---|---|---|
+| `"p"`, `"pin"`, `"pinned"` | pinned | `[-1, 0]` |
+| `"r"`, `"roller"` | roller | `[-1, 0]` |
+| `"e"`, `"encastre"`, `"fixed"`, `"clamped"` | fully fixed | `[-1, -1]` |
+| `"f"`, `"free"` | free (e.g. a cantilever tip) | `[0, 0]` |
+
+Names are case-insensitive. The two letters `e` (encastre) and `f` (free) are
+deliberately distinct so a built-in support is never confused with a free end.
+In a beam, `pin` and `roller` are identical (there is no horizontal DOF to
+distinguish them); both names are kept for readability. The same vocabulary
+drives `parse_beam_string` (described under *Element Types*, below), so the two
+entry points stay in lockstep.
+
+```python
+# These two beams are identical:
+ba = cba.BeamAnalysis(L=[7.5, 7.0], EI=30e4, supports=["p", "r", "r"])
+ba = cba.BeamAnalysis(L=[7.5, 7.0], EI=30e4, R=[-1, 0, -1, 0, -1, 0])
+```
+
+An **elastic spring** carries a stiffness value, which a name cannot, so give
+that node a raw `[vertical, rotation]` pair instead — this is also the general
+escape hatch back to the `R` convention:
+
+```python
+# Vertical spring (k = 5e4) at the middle node, rotation free:
+ba = cba.BeamAnalysis(L=[7.5, 7.0], EI=30e4, supports=["p", [5e4, 0], "p"])
+```
+
+`supports` and `R` are mutually exclusive (pass one or the other), and
+`supports_to_R(supports)` is available if you want the lowered vector directly.
+An **internal hinge is not a support** — it is a moment release *between* two
+members — so it cannot appear in `supports`; release the moment on the adjacent
+member through its element type (`FP`/`PF`/`PP`; see *Element Types*, below)
+instead.
+
 If the restraints leave the structure under-supported, it is a *mechanism* —
 the stiffness matrix is singular and the solution is meaningless. Before
 solving, `analyze()` checks the free-DOF stiffness for this condition and

--- a/docs/source/notebooks/intro.ipynb
+++ b/docs/source/notebooks/intro.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "L = [7.5, 7.0]\n",
     "EI = 30 * 600e7 * 1e-6\n",
-    "R = [-1, 0, -1, 0, -1, 0]"
+    "supports = [\"p\", \"r\", \"r\"]  # one per node: A pinned, B and C rollers"
    ]
   },
   {
@@ -88,7 +88,7 @@
     "\n",
     "The flexural rigidity (elastic modulus multiplied by the second moment of area) can be defined for each member, or if a scalar value is passed, this is assigned to all members. Here we take $E = 30$ GPa and $I = 600 \\times 10^7$ mm$^4$, and apply a conversion to put it into a consistent set of units (kN and m).\n",
     "\n",
-    "The beam restraints at each nodal degree of freedom are then defined. Since there are three nodes, this will be a vector of $2 \\times 3 = 6$ entries. Only the vertical (and not rotational) degree of freedom is restrained at nodes $A$, $B$, and $C$, and so this is indicated using $-1$ and $0$ for unrestrained.\n",
+    "The supports are then named, one per node from left to right. All three nodes $A$, $B$ and $C$ carry a vertical support: here $A$ is a pin and $B$, $C$ are rollers (in a beam these are equivalent \u2014 both hold the vertical degree of freedom and leave the rotation free). Internally `PyCBA` stores this as a restraint vector `R` that lists both degrees of freedom (vertical then rotation) at every node, so with three nodes it has $2 \\times 3 = 6$ entries, using $-1$ for a restrained degree of freedom and $0$ for a free one; thus `supports=[\"p\", \"r\", \"r\"]` is exactly `R=[-1, 0, -1, 0, -1, 0]`. Either form may be passed \u2014 see the user guide for the full vocabulary, including fixed supports, free ends and springs.\n",
     "\n",
     "With the basic variables defined, we construct the `beam_analysis` object by passing these variables."
    ]
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "beam_analysis = cba.BeamAnalysis(L, EI, R)"
+    "beam_analysis = cba.BeamAnalysis(L, EI, supports=supports)"
    ]
   },
   {

--- a/src/pycba/__init__.py
+++ b/src/pycba/__init__.py
@@ -21,7 +21,7 @@ from .results import BeamResults, Envelopes
 from .render import BeamPlotter
 from .units import UnitSystem, set_units, get_units
 from .inf_lines import InfluenceLines
-from .utils import parse_beam_string
+from .utils import parse_beam_string, supports_to_R
 from .bridge import BridgeAnalysis
 from .vehicle import Vehicle, make_train, VehicleLibrary
 from .load_cases import (

--- a/src/pycba/analysis.py
+++ b/src/pycba/analysis.py
@@ -37,7 +37,7 @@ An OO Python adaptation of CBA, originally written for MATLAB:
 http://www.colincaprani.com/programming/matlab/
 """
 
-from typing import Union, Optional
+from typing import Optional, Sequence, Union
 import numpy as np
 import matplotlib.pyplot as plt
 from .beam import Beam, LoadMatrix
@@ -69,10 +69,11 @@ class BeamAnalysis:
         self,
         L: np.ndarray,
         EI: Union[float, np.ndarray],
-        R: np.ndarray,
+        R: Optional[np.ndarray] = None,
         LM: Optional[LoadMatrix] = None,
         eletype: Optional[np.ndarray] = None,
         D: Optional[list] = None,
+        supports: Optional[Sequence] = None,
     ):
         """
         Construct a beam analysis object.
@@ -88,7 +89,7 @@ class BeamAnalysis:
             given as a :class:`~pycba.section.SectionEI` is treated as
             **non-prismatic** (variable ``EI``) and analysed by flexibility
             integration; scalar entries use the closed-form prismatic element.
-        R : array_like of int or float
+        R : array_like of int or float, optional
             Nodal restraint vector, length ``2(N+1)``.  Two entries per node
             (vertical DOF then rotational DOF), ordered left to right:
 
@@ -96,6 +97,8 @@ class BeamAnalysis:
               by ``D``).
             * ``0``  — free.
             * ``+k`` — elastic spring stiffness in consistent units.
+
+            Provide either ``R`` or the friendlier ``supports``, not both.
 
         LM : list of list, optional
             Load matrix: a list of load descriptors.  The number of columns
@@ -130,12 +133,27 @@ class BeamAnalysis:
             settlement — negative = downward).  Fixed supports (``R = -1``)
             default to zero displacement unless ``D`` provides an explicit
             override.
+        supports : sequence of (str or [float, float]), optional
+            A friendlier alternative to ``R``: one entry per node (left to
+            right), each a support name or a raw ``[vertical, rotation]`` DOF
+            pair.  Recognised names (case-insensitive):
+
+            * ``"p"`` / ``"pin"`` / ``"pinned"`` and ``"r"`` / ``"roller"`` —
+              vertical held, rotation free.
+            * ``"e"`` / ``"encastre"`` / ``"fixed"`` / ``"clamped"`` — fully
+              fixed.
+            * ``"f"`` / ``"free"`` — unrestrained (e.g. a cantilever tip).
+
+            Elastic springs are given as a raw pair, e.g. ``[5e4, 0]`` for a
+            vertical spring.  Lowered to ``R`` via
+            :func:`~pycba.supports_to_R`; mutually exclusive with ``R``.
 
         Raises
         ------
         ValueError
-            If ``R`` and ``D`` have different lengths, or ``EI`` is not
-            scalar and its length differs from ``len(L)``.
+            If both ``R`` and ``supports`` (or neither) are given, ``R`` and
+            ``D`` have different lengths, or ``EI`` is not scalar and its length
+            differs from ``len(L)``.
         """
         self.npts = 100
         self._beam_results = None
@@ -145,7 +163,9 @@ class BeamAnalysis:
         else:
             self.eletype = eletype
         # Create the beam
-        self._beam = Beam(L=L, EI=EI, R=R, LM=LM, eletype=self.eletype, D=D)
+        self._beam = Beam(
+            L=L, EI=EI, R=R, LM=LM, eletype=self.eletype, D=D, supports=supports
+        )
 
         self._n = self._beam.no_spans
         self._no_nodes = self._n + 1

--- a/src/pycba/beam.py
+++ b/src/pycba/beam.py
@@ -1,12 +1,13 @@
 """
 PyCBA - Beam Class definition
 """
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 import numpy as np
 from scipy import integrate
 from .load import parse_LM, LoadType, LoadMatrix, LoadCNL, LoadIC
 from .types import MemberType
 from .section import SectionEI
+from .utils import supports_to_R, SupportType
 
 
 class Beam:
@@ -22,6 +23,7 @@ class Beam:
         LM: Optional[LoadMatrix] = None,
         eletype: Optional[np.ndarray] = None,
         D: Optional[np.ndarray] = None,
+        supports: Optional[Sequence[SupportType]] = None,
     ):
         """
         Constructs a beam object
@@ -33,7 +35,9 @@ class Beam:
         EI : np.ndarray
             A vector of member flexural rigidities.
         R : np.ndarray
-            A vector describing the support conditions at each member end.
+            A vector describing the support conditions at each member end (the
+            low-level restraint vector).  Provide either ``R`` or the friendlier
+            ``supports``, not both.
         LM : Optional[list[list[Union[int, float]]]]
             The load matrix: a list of loads on the beam; each load with several
             parameters.
@@ -44,6 +48,13 @@ class Beam:
         D : Optional[np.ndarray]
             A vector of prescribed displacements. Must have same length as R.
             Use None for DOFs without prescribed displacement.
+        supports : Optional[Sequence[str or [float, float]]]
+            A friendlier alternative to ``R``: one entry per node (left to
+            right), each a support name (``"p"``/``"pin"``/``"pinned"``,
+            ``"r"``/``"roller"``, ``"e"``/``"encastre"``/``"fixed"``,
+            ``"f"``/``"free"``) or a raw ``[vertical, rotation]`` DOF pair (e.g.
+            ``[5e4, 0]`` for a vertical spring).  Lowered to ``R`` via
+            :func:`~pycba.supports_to_R`.  Mutually exclusive with ``R``.
 
 
         Returns
@@ -66,6 +77,15 @@ class Beam:
         # be invalidated.  Load changes deliberately do not bump it.
         self._structure_version = 0
 
+        # The friendly ``supports`` list is sugar for the low-level ``R`` vector;
+        # lower it here so the rest of the constructor is unchanged.
+        if supports is not None:
+            if R is not None:
+                raise ValueError("Pass either R or supports, not both.")
+            if L is None:
+                raise ValueError("supports requires L to set the node count.")
+            R = supports_to_R(supports, n_nodes=len(L) + 1)
+
         if L is not None and eletype is not None:
             # A single rigidity (scalar EI, or one SectionEI) applies to all
             # spans; otherwise one rigidity per span is required.
@@ -78,6 +98,8 @@ class Beam:
                         self.add_span(l, ei, et)
                 else:
                     raise ValueError("Define EI for each span")
+            if R is None:
+                raise ValueError("Provide support conditions via R or supports.")
             if len(R) == 2 * len(L) + 2:
                 self._restraints = R
             else:

--- a/src/pycba/utils.py
+++ b/src/pycba/utils.py
@@ -3,7 +3,136 @@ PyCBA - Utility functions for interacting with PyCBA
 """
 import re
 import numpy as np
-from typing import Tuple
+from typing import List, Optional, Sequence, Tuple, Union
+
+
+# Per-node support-name vocabulary, shared by :func:`parse_beam_string` and the
+# friendlier ``supports=`` constructor argument.  Each name lowers to a
+# ``[vertical, rotation]`` restraint pair in the ``R`` convention (``-1`` = fixed,
+# ``0`` = free); a 1D beam node carries only these two DOFs.  Pin and roller are
+# identical in a beam (no horizontal DOF distinguishes them); both names are kept
+# for readability and visualisation intent.
+_SUPPORT_DOF = {
+    "p": [-1, 0],
+    "pin": [-1, 0],
+    "pinned": [-1, 0],
+    "r": [-1, 0],
+    "roller": [-1, 0],
+    "e": [-1, -1],
+    "encastre": [-1, -1],
+    "fixed": [-1, -1],
+    "clamped": [-1, -1],
+    "f": [0, 0],
+    "free": [0, 0],
+}
+
+# Support type that is *not* a ground restraint but an internal moment release;
+# only meaningful inside a beam string (where it also pins the previous member).
+_HINGE_NAMES = {"h", "hinge"}
+
+SupportType = Union[str, Sequence[float]]
+
+
+def _support_pair(entry: SupportType) -> List[float]:
+    """
+    Lower a single per-node support to its ``[vertical, rotation]`` DOF pair.
+
+    Parameters
+    ----------
+    entry : str or sequence of float
+        Either a support name (case-insensitive; see :data:`_SUPPORT_DOF`) or a
+        raw two-element ``[vertical, rotation]`` restraint pair in the ``R``
+        convention.  A pair is the escape hatch for elastic springs, e.g.
+        ``[5e4, 0]`` is a vertical spring of stiffness ``5e4`` with the rotation
+        free.
+
+    Raises
+    ------
+    ValueError
+        If a name is unknown, names an internal hinge (which is a member
+        release, not a support), or a numeric pair does not have exactly two
+        entries.
+    """
+    if isinstance(entry, str):
+        key = entry.strip().lower()
+        if key in _HINGE_NAMES:
+            raise ValueError(
+                "A hinge is an internal moment release, not a support; do not "
+                "list it in `supports`. Release the moment on the adjacent "
+                "member via its element type instead (e.g. eletype 'FP'/'PF')."
+            )
+        try:
+            return list(_SUPPORT_DOF[key])
+        except KeyError:
+            names = ", ".join(sorted(_SUPPORT_DOF))
+            raise ValueError(
+                f"Unknown support {entry!r}; use one of: {names}; or a raw "
+                f"[vertical, rotation] DOF pair (e.g. [5e4, 0] for a spring)."
+            )
+    pair = list(entry)
+    if len(pair) != 2:
+        raise ValueError(
+            f"A support DOF pair must have exactly 2 entries "
+            f"[vertical, rotation], got {entry!r}."
+        )
+    return pair
+
+
+def supports_to_R(
+    supports: Sequence[SupportType], n_nodes: Optional[int] = None
+) -> list:
+    """
+    Lower a per-node list of named supports to a raw restraint vector ``R``.
+
+    This is the friendly front-end to the low-level ``R`` vector used throughout
+    PyCBA: one entry per node (left to right), each either a support *name* or a
+    raw ``[vertical, rotation]`` DOF pair.  The result is exactly the ``R`` you
+    would otherwise write by hand, so ``supports=`` and ``R=`` are
+    interchangeable on the :class:`~pycba.Beam` / :class:`~pycba.BeamAnalysis`
+    constructors.
+
+    Recognised names (case-insensitive):
+
+    * ``"p"`` / ``"pin"`` / ``"pinned"`` and ``"r"`` / ``"roller"`` -> ``[-1, 0]``
+      (vertical held, rotation free).
+    * ``"e"`` / ``"encastre"`` / ``"fixed"`` / ``"clamped"`` -> ``[-1, -1]``
+      (fully fixed).
+    * ``"f"`` / ``"free"`` -> ``[0, 0]`` (unrestrained, e.g. a cantilever tip).
+
+    Elastic springs are given as a raw pair, e.g. ``[5e4, 0]`` for a vertical
+    spring (stiffness ``5e4``) with the rotation free.
+
+    An internal hinge is **not** a support (it is a member moment release) and is
+    rejected; release the moment on the adjacent member via its element type
+    instead.
+
+    Parameters
+    ----------
+    supports : sequence of (str or [float, float])
+        One entry per node, ordered left to right.
+    n_nodes : int, optional
+        Expected number of nodes (``= number of spans + 1``).  If given, the
+        length of ``supports`` is validated against it for a clear early error.
+
+    Returns
+    -------
+    list
+        The restraint vector ``R`` of length ``2 * len(supports)``.
+
+    Raises
+    ------
+    ValueError
+        If ``n_nodes`` is given and does not match ``len(supports)``, or any
+        entry is not a recognised name or valid ``[vertical, rotation]`` pair.
+    """
+    if n_nodes is not None and len(supports) != n_nodes:
+        raise ValueError(
+            f"Expected {n_nodes} supports (one per node), got {len(supports)}."
+        )
+    R = []
+    for entry in supports:
+        R.extend(_support_pair(entry))
+    return R
 
 
 def parse_beam_string(
@@ -88,15 +217,10 @@ def parse_beam_string(
     R = []
     eType = [1 for l in L]
     for i, t in enumerate(terminals):
-        if t == "p" or t == "r":  # pin or roller
-            R.append([-1, 0])
-        elif t == "e":  # encastre
-            R.append([-1, -1])
-        elif t == "f":  # free
-            R.append([0, 0])
-        elif t == "h":  # hinge
-            R.append([0, 0])
+        if t == "h":  # internal hinge: unsupported node + release of prev member
+            R.extend([0, 0])
             eType[i - 1] = 2
-    R = [elem for sublist in R for elem in sublist]
+        else:  # p / r / e / f map via the shared support vocabulary
+            R.extend(_SUPPORT_DOF[t])
 
     return (L, EI, R, eType)

--- a/tests/test_supports.py
+++ b/tests/test_supports.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Tests for the friendly named ``supports=`` API and ``supports_to_R``."""
+
+import numpy as np
+import pytest
+import pycba as cba
+from pycba.utils import supports_to_R
+
+
+# ---------------------------------------------------------------------------
+# supports_to_R: the lowering helper
+# ---------------------------------------------------------------------------
+def test_names_lower_to_expected_R():
+    assert supports_to_R(["p", "r", "r", "e"]) == [-1, 0, -1, 0, -1, 0, -1, -1]
+    assert supports_to_R(["f", "p"]) == [0, 0, -1, 0]
+
+
+def test_letter_word_aliases_are_equivalent():
+    # pin/roller -> [-1, 0]; encastre/fixed/clamped -> [-1, -1]; free -> [0, 0]
+    assert supports_to_R(["pin", "roller", "encastre", "free"]) == supports_to_R(
+        ["p", "r", "e", "f"]
+    )
+    assert supports_to_R(["pinned"]) == supports_to_R(["p"])
+    assert (
+        supports_to_R(["fixed"]) == supports_to_R(["clamped"]) == supports_to_R(["e"])
+    )
+
+
+def test_case_insensitive_and_whitespace_tolerant():
+    assert supports_to_R([" Pin ", "ROLLER", "Encastre"]) == [-1, 0, -1, 0, -1, -1]
+
+
+def test_spring_given_as_raw_pair():
+    # A raw [vertical, rotation] pair is the escape hatch (and the spring form).
+    assert supports_to_R(["p", [5e4, 0], "p"]) == [-1, 0, 5e4, 0, -1, 0]
+    # A raw pair may also restate a named support.
+    assert supports_to_R([[-1, 0], [-1, -1]]) == [-1, 0, -1, -1]
+
+
+def test_n_nodes_validation():
+    assert supports_to_R(["p", "r", "r"], n_nodes=3) == [-1, 0, -1, 0, -1, 0]
+    with pytest.raises(ValueError, match="Expected 3 supports"):
+        supports_to_R(["p", "r"], n_nodes=3)
+
+
+def test_unknown_name_rejected():
+    with pytest.raises(ValueError, match="Unknown support 'x'"):
+        supports_to_R(["p", "x"])
+
+
+def test_hinge_rejected_with_guidance():
+    # A hinge is a member release, not a support: it must not appear in supports.
+    with pytest.raises(ValueError, match="hinge is an internal moment release"):
+        supports_to_R(["p", "hinge", "r"])
+    with pytest.raises(ValueError, match="hinge"):
+        supports_to_R(["p", "h", "r"])
+
+
+def test_bad_pair_length_rejected():
+    with pytest.raises(ValueError, match="exactly 2 entries"):
+        supports_to_R(["p", [1, 2, 3]])
+
+
+# ---------------------------------------------------------------------------
+# supports= on the constructors
+# ---------------------------------------------------------------------------
+def _two_span_inputs():
+    L = [7.5, 7.0]
+    EI = 30 * 600e7 * 1e-6
+    LM = [[1, 1, 20, 0, 0], [2, 1, 20, 0, 0]]
+    return L, EI, LM
+
+
+def test_supports_equivalent_to_R_full_analysis():
+    L, EI, LM = _two_span_inputs()
+    ba_R = cba.BeamAnalysis(L, EI, [-1, 0, -1, 0, -1, 0], LM)
+    ba_S = cba.BeamAnalysis(L, EI, LM=LM, supports=["p", "r", "r"])
+    assert ba_R.analyze() == 0
+    assert ba_S.analyze() == 0
+    assert list(ba_S.beam.restraints) == list(ba_R.beam.restraints)
+    assert np.allclose(ba_S.beam_results.R, ba_R.beam_results.R)
+    assert np.allclose(ba_S.beam_results.results.M, ba_R.beam_results.results.M)
+
+
+def test_supports_spring_equivalent_to_R_spring():
+    L, EI, LM = _two_span_inputs()
+    ba_R = cba.BeamAnalysis(L, EI, [-1, 0, 5e4, 0, -1, 0], LM)
+    ba_S = cba.BeamAnalysis(L, EI, LM=LM, supports=["p", [5e4, 0], "p"])
+    ba_R.analyze()
+    ba_S.analyze()
+    assert np.allclose(ba_S.beam_results.R, ba_R.beam_results.R)
+    assert np.allclose(ba_S.beam_results.Rs, ba_R.beam_results.Rs)
+
+
+def test_supports_on_beam_object():
+    L, EI, _ = _two_span_inputs()
+    beam = cba.Beam(L=L, EI=EI, eletype=np.ones((len(L), 1)), supports=["p", "r", "r"])
+    assert list(beam.restraints) == [-1, 0, -1, 0, -1, 0]
+
+
+def test_cantilever_free_end_via_supports():
+    # Propped cantilever: encastre then free tip.
+    L, EI = [5.0], 1e8
+    ba = cba.BeamAnalysis(L, EI, LM=[[1, 1, 10]], supports=["e", "f"])
+    assert ba.analyze() == 0
+    assert list(ba.beam.restraints) == [-1, -1, 0, 0]
+
+
+def test_both_R_and_supports_rejected():
+    L, EI, LM = _two_span_inputs()
+    with pytest.raises(ValueError, match="either R or supports"):
+        cba.BeamAnalysis(L, EI, [-1, 0, -1, 0, -1, 0], LM, supports=["p", "r", "r"])
+
+
+def test_neither_R_nor_supports_rejected():
+    L, EI, _ = _two_span_inputs()
+    with pytest.raises(ValueError, match="R or supports"):
+        cba.BeamAnalysis(L, EI)
+
+
+def test_wrong_support_count_rejected():
+    L, EI, _ = _two_span_inputs()  # 2 spans -> 3 nodes expected
+    with pytest.raises(ValueError, match="Expected 3 supports"):
+        cba.BeamAnalysis(L, EI, supports=["p", "r"])
+
+
+# ---------------------------------------------------------------------------
+# parse_beam_string still agrees after the shared-table refactor
+# ---------------------------------------------------------------------------
+def test_parse_beam_string_unchanged():
+    L, EI, R, eType = cba.parse_beam_string("P40R20R")
+    assert R == [-1, 0, -1, 0, -1, 0]
+    # An internal hinge: unsupported node + released previous member.
+    L, EI, R, eType = cba.parse_beam_string("E20H30R10F")
+    assert R == [-1, -1, 0, 0, -1, 0, 0, 0]
+    assert eType == [2, 1, 1]


### PR DESCRIPTION
## Summary

Specifying supports currently requires the low-level `R` restraint vector — two DOFs per node and the `-1`/`0`/`+k` convention — which is the steepest part of PyCBA's learning curve. This PR adds a friendlier, self-documenting alternative: a `supports=` list with **one entry per node**.

```python
# Equivalent:
cba.BeamAnalysis(L=[7.5, 7.0], EI=30e4, supports=["p", "r", "r"])
cba.BeamAnalysis(L=[7.5, 7.0], EI=30e4, R=[-1, 0, -1, 0, -1, 0])

# Springs via a raw [vertical, rotation] pair; names for the rest:
cba.BeamAnalysis(L=[5, 5], EI=30e4, supports=["e", [5e4, 0], "f"])
```

## Vocabulary

Reuses the exact letter vocabulary already in `parse_beam_string`, so the two entry points share one mapping:

| Name(s) | Meaning | `[vertical, rotation]` |
|---|---|---|
| `p` / `pin` / `pinned`, `r` / `roller` | pinned / roller | `[-1, 0]` |
| `e` / `encastre` / `fixed` / `clamped` | fully fixed | `[-1, -1]` |
| `f` / `free` | free (e.g. a cantilever tip) | `[0, 0]` |

Names are case-insensitive. Elastic springs are given as a raw `[v, θ]` pair (e.g. `[5e4, 0]`), which is also the general escape hatch back to the `R` convention.

## Implementation

- **`utils.py`**: factored the inline letter→DOF map out of `parse_beam_string` into a shared `_SUPPORT_DOF` table plus a public `supports_to_R()` helper. The parser now calls it — a behaviour-preserving refactor guarded by the existing `test_inf_lines` suite.
- **`Beam` / `BeamAnalysis`**: new `supports=` argument that lowers to `R` in `Beam.__init__`. `R` is now optional; passing both (or neither) raises a clear error. `R` remains fully supported as the low-level form and stays the 3rd positional argument, so every existing call is unchanged.
- **`__init__.py`**: exports `supports_to_R`.

## Design note: hinges are not supports

An internal hinge is a moment release *between* two members, not a node-to-ground restraint, so it is rejected in `supports=` with guidance to use the member element type (`FP`/`PF`/`PP`) instead. The "supported hinge" case (a hinge sitting over a support) is intentionally left for a future member-level hinge spec rather than overloaded into the support list.

## Docs & tests

- `docs/source/general.md`: new "Named supports" section (vocabulary table, springs, hinge caveat).
- Intro tutorial **Example 1** now leads with `supports=["p", "r", "r"]`, explaining the equivalent `R` vector.
- `tests/test_supports.py`: **16 tests** — name/letter/word equivalence, springs, `supports ≡ R` end-to-end, all error paths, plus a `parse_beam_string` refactor guard.

## Test plan

- `tests/test_supports.py` (16) pass.
- Suites that exercise the changed code paths pass: `test_basic`, `test_member_type`, `test_inf_lines`, `test_results`, `test_units`.
- Black-clean (23.x style, matching the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
