### PR TITLE
CI: add pandas to test deps for to_dataframe tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Source = "https://github.com/ccaprani/pycba/"
 Tracker = "https://github.com/ccaprani/pycba/issues/"
 
 [project.optional-dependencies]
-test = ["pytest >= 6.2.2"]
+test = ["pytest >= 6.2.2", "pandas"]
 plotly = ["plotly >= 5.0"]
 
 [tool.setuptools]

--- a/tests/test_results_export.py
+++ b/tests/test_results_export.py
@@ -36,6 +36,7 @@ def test_at_before_analysis_returns_none():
 
 
 def test_to_dataframe_columns_and_length():
+    pytest.importorskip("pandas")  # to_dataframe() needs the optional pandas
     ba = _ss_udl()
     df = ba.to_dataframe()
     assert list(df.columns) == ["x", "M", "V", "R", "D"]
@@ -62,6 +63,7 @@ def test_to_csv_roundtrip(tmp_path):
 
 
 def test_envelopes_export(tmp_path):
+    pytest.importorskip("pandas")  # to_dataframe() needs the optional pandas
     ba = cba.BeamAnalysis([20.0, 20.0], 1e8, [-1, 0, -1, 0, -1, 0])
     veh = cba.VehicleLibrary.US.get_hl93_truck()
     env = cba.BridgeAnalysis(ba, veh).run_vehicle(2.0)


### PR DESCRIPTION
The `to_dataframe()` export needs the optional **pandas**, which the CI `.[test]` install lacked — so `test_to_dataframe_columns_and_length` and `test_envelopes_export` hard-failed (the `to_csv` tests use numpy and passed). Adds `pandas` to the `test` extra so CI installs and exercises it, and guards both tests with `pytest.importorskip("pandas")` so the suite passes with or without pandas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)