### PR TITLE
Release 1.0.1 (first AGPL-3.0 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 1.0.0 — 2026-06-27
+## 1.0.1 — 2026-06-28
 
 ### Licensing
-- **PyCBA is now licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)**, changed from Apache 2.0. You remain free to *use* PyCBA for any purpose, including commercial and professional work; but software that **incorporates** PyCBA — whether distributed or offered over a network (SaaS) — must in turn be released under the AGPL.
+- **Relicensed to the GNU Affero General Public License v3.0 (AGPL-3.0)** (from Apache 2.0). Version 1.0.0 was inadvertently published under Apache 2.0 before the relicense landed, so **1.0.1 is the first AGPL release** — please use it. You remain free to *use* PyCBA for any purpose, including commercial and professional work; but software that **incorporates** PyCBA — whether distributed or offered over a network (SaaS) — must in turn be released under the AGPL. Functionally identical to 1.0.0 otherwise.
+
+## 1.0.0 — 2026-06-27
 
 ### Features
 - **Collapse-mechanism plot**: `NonlinearResult.plot_collapse()` draws the deflected shape at failure with a large marker at each plastic hinge — the standard plastic-collapse picture. The collapse displacement field is now stored on the result.

--- a/src/pycba/__init__.py
+++ b/src/pycba/__init__.py
@@ -2,7 +2,7 @@
 PyCBA - Continuous Beam Analysis in Python
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from .analysis import BeamAnalysis
 from .beam import Beam


### PR DESCRIPTION
1.0.0 was published to PyPI under **Apache 2.0** before the AGPL relicense (#173) merged. PyPI versions are immutable, so this ships **1.0.1** — functionally identical to 1.0.0 but under **AGPL-3.0** (the intended licence). Bumps the version and moves the licensing note to a 1.0.1 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)