### PR TITLE
changelog: fold into 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 ## 1.0.1 — 2026-06-28
 
 ### Licensing
-- **Relicensed to the GNU Affero General Public License v3.0 (AGPL-3.0)** (from Apache 2.0). Version 1.0.0 was inadvertently published under Apache 2.0 before the relicense landed, so **1.0.1 is the first AGPL release** — please use it. You remain free to *use* PyCBA for any purpose, including commercial and professional work; but software that **incorporates** PyCBA — whether distributed or offered over a network (SaaS) — must in turn be released under the AGPL. Functionally identical to 1.0.0 otherwise.
-
-## 1.0.0 — 2026-06-27
+- **Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0).** You may freely *use* PyCBA for any purpose, including commercial and professional work; but software that **incorporates** PyCBA — whether distributed or offered over a network (SaaS) — must in turn be released under the AGPL.
 
 ### Features
 - **Collapse-mechanism plot**: `NonlinearResult.plot_collapse()` draws the deflected shape at failure with a large marker at each plastic hinge — the standard plastic-collapse picture. The collapse displacement field is now stored on the result.


### PR DESCRIPTION
1.0.0 was withdrawn (deleted from PyPI and GitHub); fold its entries into the 1.0.1 release section and drop the standalone 1.0.0 heading + the withdrawal note, so the public record is simply '1.0.1 — the AGPL 1.0 release'.